### PR TITLE
405 task links

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -74,6 +74,43 @@
       "problemMatcher": []
     },
     {
+      "label": "Start Data Management App (Utah Water Rights Dev)",
+      "type": "shell",
+      "command": "npm run dev",
+      "options": {
+        "cwd": "${workspaceFolder}/apps/data-management",
+        "env": {
+          "VITE_APP_PROXY_BASE_URL": "https://hydroserverdev.waterrights.utah.gov",
+          "VITE_HYDROSERVER_CLIENT_LOCAL": "1",
+          "VITE_HYDROSERVER_CLIENT_PATH": "${workspaceFolder}/packages/hydroserver-ts/src"
+        }
+      },
+      "presentation": {
+        "group": "utah-water-rights-dev",
+        "panel": "dedicated",
+        "reveal": "always"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Start QC App (Utah Water Rights Dev)",
+      "type": "shell",
+      "command": "npm run dev:qc",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VITE_APP_PROXY_BASE_URL": "https://hydroserverdev.waterrights.utah.gov",
+          "VITE_APP_DISABLE_COOP": "1"
+        }
+      },
+      "presentation": {
+        "group": "utah-water-rights-dev",
+        "panel": "dedicated",
+        "reveal": "always"
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "Start Backend",
       "type": "shell",
       "command": "${workspaceFolder}/scripts/dev-api-command manage.py runserver 0.0.0.0:8000",
@@ -136,6 +173,15 @@
       "dependsOn": [
         "Start Data Management App (Playground)",
         "Start QC App (Playground)"
+      ],
+      "dependsOrder": "parallel",
+      "problemMatcher": []
+    },
+    {
+      "label": "Start Frontends Against Utah Water Rights Dev",
+      "dependsOn": [
+        "Start Data Management App (Utah Water Rights Dev)",
+        "Start QC App (Utah Water Rights Dev)"
       ],
       "dependsOrder": "parallel",
       "problemMatcher": []

--- a/apps/data-management/e2e/specs/sites.spec.ts
+++ b/apps/data-management/e2e/specs/sites.spec.ts
@@ -255,7 +255,7 @@ test.describe('sites and workspaces', () => {
     await page.getByRole('button', { name: 'Create datastream' }).click()
 
     const datastreamRow = page
-      .locator('tr, .datastream-card')
+      .locator('[data-datastream-id]')
       .filter({ hasText: datastreamName })
       .first()
     await expect(datastreamRow).toBeVisible()
@@ -266,7 +266,7 @@ test.describe('sites and workspaces', () => {
     await page.getByRole('button', { name: 'Update datastream' }).click()
 
     const renamedDatastreamRow = page
-      .locator('tr, .datastream-card')
+      .locator('[data-datastream-id]')
       .filter({ hasText: renamedDatastreamName })
       .first()
     await expect(renamedDatastreamRow).toBeVisible()
@@ -278,7 +278,7 @@ test.describe('sites and workspaces', () => {
     await page.locator('input').last().fill('Delete')
     await page.getByRole('button', { name: 'Confirm' }).click()
     await expect(
-      page.locator('tr, .datastream-card').filter({
+      page.locator('[data-datastream-id]').filter({
         hasText: renamedDatastreamName,
       })
     ).toHaveCount(0)
@@ -363,7 +363,7 @@ test.describe('sites and workspaces', () => {
       .toBe(true)
     await anonymousPage.goto(`/sites/${fixtures.things.public.id}`)
     await expect(
-      anonymousPage.locator('tr, .datastream-card').filter({
+      anonymousPage.locator('[data-datastream-id]').filter({
         hasText: fixtures.datastreams.public.name,
       })
     ).toHaveCount(0)
@@ -399,7 +399,7 @@ test.describe('sites and workspaces', () => {
       .toBe(false)
     await anonymousPage.goto(`/sites/${fixtures.things.public.id}`)
     const anonymousPublicDatastreamRow = anonymousPage
-      .locator('tr, .datastream-card')
+      .locator('[data-datastream-id]')
       .filter({
         hasText: fixtures.datastreams.public.name,
       })
@@ -417,7 +417,7 @@ test.describe('sites and workspaces', () => {
 
     await anonymousPage.goto(`/sites/${fixtures.things.public.id}`)
     await expect(
-      anonymousPage.locator('tr, .datastream-card').filter({
+      anonymousPage.locator('[data-datastream-id]').filter({
         hasText: fixtures.datastreams.public.name,
       })
     ).toHaveCount(1)
@@ -432,7 +432,7 @@ test.describe('sites and workspaces', () => {
     await page.goto(`/sites/${fixtures.things.public.id}`)
 
     const datastreamRow = page
-      .locator('tr, .datastream-card')
+      .locator('[data-datastream-id]')
       .filter({ hasText: fixtures.datastreams.public.name })
       .first()
     await expect(datastreamRow).toBeVisible()
@@ -486,7 +486,7 @@ test.describe('sites and workspaces', () => {
 
     await page.goto(`/sites/${fixtures.things.public.id}`)
     const datastreamRow = page
-      .locator('tr, .datastream-card')
+      .locator('[data-datastream-id]')
       .filter({ hasText: fixtures.datastreams.public.name })
       .first()
     await datastreamRow

--- a/apps/data-management/package-lock.json
+++ b/apps/data-management/package-lock.json
@@ -49,7 +49,7 @@
     },
     "../../packages/hydroserver-ts": {
       "name": "@hydroserver/client",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.0-beta.3",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@types/node": "^24.1.0",

--- a/apps/data-management/src/components/Datastream/DatastreamTable.vue
+++ b/apps/data-management/src/components/Datastream/DatastreamTable.vue
@@ -241,8 +241,65 @@
               :append-icon="mdiChevronRight"
               :to="linkedTasksForDatastream(item.id)[0].route"
             >
-              Manage
+              Manage task
             </v-btn>
+            <div
+              v-if="monitoringTasksForDatastream(item.id).length"
+              class="datastream-task-link__monitoring"
+            >
+              <v-icon
+                :icon="mdiShieldCheckOutline"
+                size="20"
+                class="datastream-task-link__monitoring-icon"
+              />
+              <div class="datastream-task-link__monitoring-body">
+                <span class="datastream-task-link__label">
+                  Quality monitoring
+                </span>
+                <span
+                  v-for="task in monitoringTasksForDatastream(item.id)"
+                  :key="task.id"
+                  class="datastream-task-link__monitoring-task"
+                >
+                  <RouterLink
+                    class="datastream-task-link__name"
+                    :to="task.route"
+                  >
+                    {{ task.displayName }}
+                  </RouterLink>
+                  <span
+                    class="datastream-task-link__quality-outcome"
+                    :class="monitoringOutcomeClass(task)"
+                  >
+                    {{ monitoringOutcomeLabel(task) }}
+                  </span>
+                  <span
+                    class="datastream-task-link__status"
+                    :title="monitoringLastRunStatus(task)"
+                  >
+                    <span
+                      class="datastream-task-link__dot"
+                      :style="{
+                        backgroundColor: monitoringLastRunColor(task),
+                      }"
+                    />
+                    <span class="datastream-task-link__last-ran">
+                      {{ lastRanLabel(task) }}
+                    </span>
+                  </span>
+                </span>
+              </div>
+              <v-btn
+                v-if="monitoringTasksForDatastream(item.id).length === 1"
+                size="small"
+                variant="text"
+                color="primary"
+                :append-icon="mdiChevronRight"
+                :to="monitoringTasksForDatastream(item.id)[0].route"
+              >
+                Manage monitoring
+              </v-btn>
+            </div>
           </div>
           <div
             v-else-if="showTaskSkeleton"
@@ -831,8 +888,60 @@
             :append-icon="mdiChevronRight"
             :to="linkedTasksForDatastream(item.id)[0].route"
           >
-            Manage
+            Manage task
           </v-btn>
+          <div
+            v-if="monitoringTasksForDatastream(item.id).length"
+            class="datastream-task-link__monitoring"
+          >
+            <v-icon
+              :icon="mdiShieldCheckOutline"
+              size="20"
+              class="datastream-task-link__monitoring-icon"
+            />
+            <div class="datastream-task-link__monitoring-body">
+              <span class="datastream-task-link__label">
+                Quality monitoring
+              </span>
+              <span
+                v-for="task in monitoringTasksForDatastream(item.id)"
+                :key="task.id"
+                class="datastream-task-link__monitoring-task"
+              >
+                <RouterLink class="datastream-task-link__name" :to="task.route">
+                  {{ task.displayName }}
+                </RouterLink>
+                <span
+                  class="datastream-task-link__quality-outcome"
+                  :class="monitoringOutcomeClass(task)"
+                >
+                  {{ monitoringOutcomeLabel(task) }}
+                </span>
+                <span
+                  class="datastream-task-link__status"
+                  :title="monitoringLastRunStatus(task)"
+                >
+                  <span
+                    class="datastream-task-link__dot"
+                    :style="{ backgroundColor: monitoringLastRunColor(task) }"
+                  />
+                  <span class="datastream-task-link__last-ran">
+                    {{ lastRanLabel(task) }}
+                  </span>
+                </span>
+              </span>
+            </div>
+            <v-btn
+              v-if="monitoringTasksForDatastream(item.id).length === 1"
+              size="small"
+              variant="text"
+              color="primary"
+              :append-icon="mdiChevronRight"
+              :to="monitoringTasksForDatastream(item.id)[0].route"
+            >
+              Manage monitoring
+            </v-btn>
+          </div>
         </div>
         <div
           v-else-if="showTaskSkeleton"
@@ -925,7 +1034,13 @@ import { useTableLogic } from '@/composables/useTableLogic'
 import { Snackbar } from '@/utils/notifications'
 import { downloadDatastreamCsv } from '@/utils/csvExport'
 import { formatTime } from '@/utils/time'
-import { getTaskStatusText } from '@/utils/orchestration/taskRunDetails'
+import {
+  countDistinctMonitoringViolationRules,
+  getMonitoringRulesViolated,
+  getMonitoringRunViolations,
+  getTaskRunStatusText,
+  getTaskStatusText,
+} from '@/utils/orchestration/taskRunDetails'
 import DatastreamTableInfoCard from './DatastreamTableInfoCard.vue'
 import ObservationsDeleteCard from '../Observation/ObservationsDeleteCard.vue'
 import VisibilityTooltipCard from '@/components/Datastream/VisibilityTooltipCard.vue'
@@ -951,6 +1066,7 @@ import {
   mdiMagnify,
   mdiPencil,
   mdiPlus,
+  mdiShieldCheckOutline,
   mdiSigma,
 } from '@mdi/js'
 
@@ -975,6 +1091,13 @@ type LinkedDatastreamTask = {
     params: { view: string }
     query: Record<string, string>
   }
+}
+
+type LinkedMonitoringTask = LinkedDatastreamTask & {
+  ruleCount: number
+  violationCount: number | null
+  latestRunStatus: string | null
+  lastRunStatus: StatusType
 }
 
 const { thing } = storeToRefs(useThingStore())
@@ -1044,6 +1167,9 @@ const latestValues = reactive<
 const linkedTasksByDatastreamId = ref<Record<string, LinkedDatastreamTask[]>>(
   {}
 )
+const monitoringTasksByDatastreamId = ref<
+  Record<string, LinkedMonitoringTask[]>
+>({})
 const linkedTasksLoaded = ref(false)
 const linkedTasksErrored = ref(false)
 let linkedTasksRequestId = 0
@@ -1241,6 +1367,9 @@ const mobileDatastreams = computed(() => {
 const linkedTasksForDatastream = (datastreamId: string) =>
   linkedTasksByDatastreamId.value[datastreamId] ?? []
 
+const monitoringTasksForDatastream = (datastreamId: string) =>
+  monitoringTasksByDatastreamId.value[datastreamId] ?? []
+
 const showTaskRow = computed(
   () => canViewOrchestrationInfo.value && linkedTasksLoaded.value
 )
@@ -1317,6 +1446,44 @@ const lastRanLabel = (task: LinkedDatastreamTask) => {
   return relative ? `Last ran ${relative}` : 'Never ran'
 }
 
+const monitoringOutcomeLabel = (task: LinkedMonitoringTask) => {
+  const ruleLabel = `${task.ruleCount} rule${task.ruleCount === 1 ? '' : 's'}`
+  if (!task.latestRunStatus) return `Not checked · ${ruleLabel}`
+  if (
+    task.latestRunStatus === 'PENDING' ||
+    task.latestRunStatus === 'STARTED'
+  ) {
+    return `Checking ${ruleLabel}`
+  }
+  if (task.latestRunStatus === 'FAILURE')
+    return `Results unavailable · ${ruleLabel}`
+  if (task.violationCount === null) return `Results unavailable · ${ruleLabel}`
+  if (task.violationCount === 0) {
+    return `${task.ruleCount}/${task.ruleCount} ${
+      task.ruleCount === 1 ? 'rule' : 'rules'
+    } passed`
+  }
+  return `${task.violationCount}/${task.ruleCount} ${
+    task.ruleCount === 1 ? 'rule' : 'rules'
+  } violated`
+}
+
+const monitoringOutcomeClass = (task: LinkedMonitoringTask) => {
+  if (task.violationCount !== null && task.violationCount > 0) {
+    return 'datastream-task-link__quality-outcome--violations'
+  }
+  if (task.latestRunStatus === 'SUCCESS' && task.violationCount === 0) {
+    return 'datastream-task-link__quality-outcome--ok'
+  }
+  return 'datastream-task-link__quality-outcome--unknown'
+}
+
+const monitoringLastRunStatus = (task: LinkedMonitoringTask): StatusType =>
+  task.lastRunStatus
+
+const monitoringLastRunColor = (task: LinkedMonitoringTask) =>
+  TASK_STATUS_DOT_COLORS[monitoringLastRunStatus(task)]
+
 const routeForIngestionTask = (task: any) => {
   const query: Record<string, string> = {
     workspace_id: props.workspace.id,
@@ -1363,11 +1530,57 @@ const routeForDataProductTask = (task: any) => {
   }
 }
 
+const routeForMonitoringTask = (task: any) => {
+  const query: Record<string, string> = {
+    workspace_id: props.workspace.id,
+    task_id: String(task.id),
+  }
+  const siteId = task.thing?.id ?? task.thingId ?? thing.value?.id
+  if (siteId) query.site_id = String(siteId)
+
+  return {
+    name: 'OrchestrationQualityDetails',
+    params: { view: 'quality' },
+    query,
+  }
+}
+
 const outputDatastreamId = (transformation: any) =>
   transformation?.outputDatastream?.id ?? transformation?.outputDatastreamId
 
 const targetDatastreamId = (mapping: any) =>
   mapping?.targetDatastream?.id ?? mapping?.targetDatastreamId
+
+const monitoredDatastreamId = (monitoredDatastream: any) =>
+  monitoredDatastream?.datastream?.id ??
+  monitoredDatastream?.datastreamId ??
+  monitoredDatastream?.id
+
+const monitoringViolationCount = (
+  task: any,
+  datastreamId: string,
+  monitoredDatastreamCount: number
+) => {
+  const latestRun = task?.latestRun
+  if (!latestRun || latestRun.status !== 'SUCCESS') return null
+
+  const totalViolations = getMonitoringRulesViolated(latestRun)
+  if (totalViolations === 0) return 0
+
+  const detailedViolations = getMonitoringRunViolations(latestRun)
+  const datastreamViolations = detailedViolations.filter(
+    (violation) => violation.datastreamId === datastreamId
+  )
+  if (datastreamViolations.length) {
+    return countDistinctMonitoringViolationRules(datastreamViolations)
+  }
+
+  if (detailedViolations.length && monitoredDatastreamCount === 1) {
+    return countDistinctMonitoringViolationRules(detailedViolations)
+  }
+
+  return monitoredDatastreamCount === 1 ? totalViolations : null
+}
 
 const taskPaused = (task: any) =>
   task.schedule ? task.schedule.enabled === false : false
@@ -1426,18 +1639,25 @@ const loadLinkedTasks = async () => {
     !items.value.length
   ) {
     linkedTasksByDatastreamId.value = {}
+    monitoringTasksByDatastreamId.value = {}
     return
   }
 
   const datastreamIds = new Set(items.value.map((d) => String(d.id)))
   try {
-    const [etlTasks, dataProductTasks] = await Promise.all([
+    const [etlTasks, dataProductTasks, monitoringTasks] = await Promise.all([
       hs.tasks.listAllItems({
         workspace_id: [props.workspace.id],
         order_by: ['name'],
         expand_related: true,
       } as any),
       hs.dataProductTasks.listAllItems({
+        workspace_id: [props.workspace.id],
+        thing_id: [site.id],
+        order_by: ['name'],
+        expand_related: true,
+      } as any),
+      hs.monitoringTasks.listAllItems({
         workspace_id: [props.workspace.id],
         thing_id: [site.id],
         order_by: ['name'],
@@ -1501,13 +1721,56 @@ const loadLinkedTasks = async () => {
       }
     }
 
+    const groupedMonitoring: Record<string, LinkedMonitoringTask[]> = {}
+    const seenMonitoring = new Set<string>()
+    for (const task of monitoringTasks ?? []) {
+      const monitoredDatastreams = (task as any).monitoredDatastreams ?? []
+      for (const monitoredDatastream of monitoredDatastreams) {
+        const datastreamId = monitoredDatastreamId(monitoredDatastream)
+        if (!datastreamId || !datastreamIds.has(String(datastreamId))) continue
+
+        const key = `${datastreamId}:${(task as any).id}`
+        if (seenMonitoring.has(key)) continue
+        seenMonitoring.add(key)
+        groupedMonitoring[String(datastreamId)] ??= []
+        groupedMonitoring[String(datastreamId)].push({
+          id: String((task as any).id),
+          name: (task as any).name,
+          dataConnectionName: null,
+          displayName: truncateTaskInfoPart(
+            (task as any).name || (task as any).id
+          ),
+          label: 'Quality monitoring',
+          icon: mdiShieldCheckOutline,
+          iconClass: 'datastream-task-link__icon--monitoring',
+          status: getTaskStatusText(task),
+          paused: taskPaused(task),
+          lastRunAt:
+            (task as any).latestRun?.startedAt ??
+            (task as any).latestRun?.finishedAt ??
+            null,
+          route: routeForMonitoringTask(task),
+          ruleCount: ((monitoredDatastream as any).rules ?? []).length,
+          violationCount: monitoringViolationCount(
+            task,
+            String(datastreamId),
+            monitoredDatastreams.length
+          ),
+          latestRunStatus: (task as any).latestRun?.status ?? null,
+          lastRunStatus: getTaskRunStatusText((task as any).latestRun),
+        })
+      }
+    }
+
     linkedTasksByDatastreamId.value = grouped
+    monitoringTasksByDatastreamId.value = groupedMonitoring
     linkedTasksLoaded.value = true
   } catch (error) {
     if (requestId !== linkedTasksRequestId) return
     console.error('Error fetching linked datastream tasks', error)
     linkedTasksErrored.value = true
     linkedTasksByDatastreamId.value = {}
+    monitoringTasksByDatastreamId.value = {}
   }
 }
 
@@ -1875,6 +2138,7 @@ const loadDatastreams = async () => {
 .datastream-task-link {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.75rem;
   width: 100%;
   margin-top: 0.75rem;
@@ -1936,13 +2200,12 @@ const loadDatastreams = async () => {
   display: block;
   flex: none;
   border-radius: 999px;
-  background:
-    linear-gradient(
-      90deg,
-      rgba(120, 144, 156, 0.14) 0%,
-      rgba(120, 144, 156, 0.28) 42%,
-      rgba(120, 144, 156, 0.14) 82%
-    );
+  background: linear-gradient(
+    90deg,
+    rgba(120, 144, 156, 0.14) 0%,
+    rgba(120, 144, 156, 0.28) 42%,
+    rgba(120, 144, 156, 0.14) 82%
+  );
   background-size: 220% 100%;
   animation: datastream-task-skeleton 1.4s ease-in-out infinite;
 }
@@ -1980,6 +2243,11 @@ const loadDatastreams = async () => {
 
 .datastream-task-link__icon--rating-curve {
   color: #283593 !important;
+}
+
+.datastream-task-link__icon--monitoring,
+.datastream-task-link__monitoring-icon {
+  color: #00695c !important;
 }
 
 .datastream-task-link__body {
@@ -2056,6 +2324,58 @@ const loadDatastreams = async () => {
   font-weight: 700;
   text-decoration: underline;
   text-underline-offset: 2px;
+}
+
+.datastream-task-link__monitoring {
+  display: flex;
+  align-items: center;
+  flex: 0 0 100%;
+  gap: 0.75rem;
+}
+
+.datastream-task-link__monitoring-body {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.65rem;
+  min-width: 0;
+}
+
+.datastream-task-link__monitoring-task {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.datastream-task-link__monitoring-task
+  + .datastream-task-link__monitoring-task {
+  padding-left: 0.65rem;
+  border-left: 1px solid rgba(0, 105, 92, 0.24);
+}
+
+.datastream-task-link__quality-outcome {
+  padding: 0.08rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.datastream-task-link__quality-outcome--ok {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.datastream-task-link__quality-outcome--violations {
+  background: #fdecea;
+  color: #b71c1c;
+}
+
+.datastream-task-link__quality-outcome--unknown {
+  background: #eceff1;
+  color: #546e7a;
 }
 
 @keyframes datastream-task-skeleton {

--- a/apps/data-management/src/components/Datastream/DatastreamTable.vue
+++ b/apps/data-management/src/components/Datastream/DatastreamTable.vue
@@ -1164,12 +1164,9 @@ const openCharts = reactive<Record<string, boolean>>({})
 const latestValues = reactive<
   Record<string, { text: string; showUnit: boolean; isBad: boolean }>
 >({})
-const linkedTasksByDatastreamId = ref<Record<string, LinkedDatastreamTask[]>>(
-  {}
-)
-const monitoringTasksByDatastreamId = ref<
-  Record<string, LinkedMonitoringTask[]>
->({})
+const rawEtlTasks = ref<any[]>([])
+const rawDataProductTasks = ref<any[]>([])
+const rawMonitoringTasks = ref<any[]>([])
 const linkedTasksLoaded = ref(false)
 const linkedTasksErrored = ref(false)
 let linkedTasksRequestId = 0
@@ -1632,18 +1629,13 @@ const loadLinkedTasks = async () => {
   linkedTasksLoaded.value = false
   linkedTasksErrored.value = false
   const site = thing.value
-  if (
-    !canViewOrchestrationInfo.value ||
-    !site ||
-    !props.workspace?.id ||
-    !items.value.length
-  ) {
-    linkedTasksByDatastreamId.value = {}
-    monitoringTasksByDatastreamId.value = {}
+  if (!canViewOrchestrationInfo.value || !site || !props.workspace?.id) {
+    rawEtlTasks.value = []
+    rawDataProductTasks.value = []
+    rawMonitoringTasks.value = []
     return
   }
 
-  const datastreamIds = new Set(items.value.map((d) => String(d.id)))
   try {
     const [etlTasks, dataProductTasks, monitoringTasks] = await Promise.all([
       hs.tasks.listAllItems({
@@ -1666,121 +1658,134 @@ const loadLinkedTasks = async () => {
     ])
     if (requestId !== linkedTasksRequestId) return
 
-    const grouped: Record<string, LinkedDatastreamTask[]> = {}
-    const seen = new Set<string>()
-
-    for (const task of etlTasks ?? []) {
-      for (const mapping of (task as any).mappings ?? []) {
-        const datastreamId = targetDatastreamId(mapping)
-        if (!datastreamId || !datastreamIds.has(String(datastreamId))) continue
-        addLinkedTask(grouped, seen, String(datastreamId), task, {
-          label: 'Fed by',
-          icon: mdiLightningBolt,
-          iconClass: 'datastream-task-link__icon--source',
-          route: routeForIngestionTask(task),
-        })
-      }
-    }
-
-    for (const task of dataProductTasks ?? []) {
-      const transformationGroups = [
-        {
-          label: 'Aggregated by',
-          icon: mdiCallMerge,
-          iconClass: 'datastream-task-link__icon--aggregation',
-          transformations: (task as any).aggregationTransformations ?? [],
-        },
-        {
-          label: 'Derived by',
-          icon: mdiSigma,
-          iconClass: 'datastream-task-link__icon--derived',
-          transformations: [
-            ...((task as any).compositeExpressionTransformations ?? []),
-            ...((task as any).expressionTransformations ?? []),
-          ],
-        },
-        {
-          label: 'Rating curve',
-          icon: mdiChartBellCurve,
-          iconClass: 'datastream-task-link__icon--rating-curve',
-          transformations: (task as any).ratingCurveTransformations ?? [],
-        },
-      ]
-      for (const group of transformationGroups) {
-        for (const transformation of group.transformations) {
-          const datastreamId = outputDatastreamId(transformation)
-          if (!datastreamId || !datastreamIds.has(String(datastreamId)))
-            continue
-          addLinkedTask(grouped, seen, String(datastreamId), task, {
-            label: group.label,
-            icon: group.icon,
-            iconClass: group.iconClass,
-            route: routeForDataProductTask(task),
-          })
-        }
-      }
-    }
-
-    const groupedMonitoring: Record<string, LinkedMonitoringTask[]> = {}
-    const seenMonitoring = new Set<string>()
-    for (const task of monitoringTasks ?? []) {
-      const monitoredDatastreams = (task as any).monitoredDatastreams ?? []
-      for (const monitoredDatastream of monitoredDatastreams) {
-        const datastreamId = monitoredDatastreamId(monitoredDatastream)
-        if (!datastreamId || !datastreamIds.has(String(datastreamId))) continue
-
-        const key = `${datastreamId}:${(task as any).id}`
-        if (seenMonitoring.has(key)) continue
-        seenMonitoring.add(key)
-        groupedMonitoring[String(datastreamId)] ??= []
-        groupedMonitoring[String(datastreamId)].push({
-          id: String((task as any).id),
-          name: (task as any).name,
-          dataConnectionName: null,
-          displayName: truncateTaskInfoPart(
-            (task as any).name || (task as any).id
-          ),
-          label: 'Quality monitoring',
-          icon: mdiShieldCheckOutline,
-          iconClass: 'datastream-task-link__icon--monitoring',
-          status: getTaskStatusText(task),
-          paused: taskPaused(task),
-          lastRunAt:
-            (task as any).latestRun?.startedAt ??
-            (task as any).latestRun?.finishedAt ??
-            null,
-          route: routeForMonitoringTask(task),
-          ruleCount: ((monitoredDatastream as any).rules ?? []).length,
-          violationCount: monitoringViolationCount(
-            task,
-            String(datastreamId),
-            monitoredDatastreams.length
-          ),
-          latestRunStatus: (task as any).latestRun?.status ?? null,
-          lastRunStatus: getTaskRunStatusText((task as any).latestRun),
-        })
-      }
-    }
-
-    linkedTasksByDatastreamId.value = grouped
-    monitoringTasksByDatastreamId.value = groupedMonitoring
+    rawEtlTasks.value = etlTasks ?? []
+    rawDataProductTasks.value = dataProductTasks ?? []
+    rawMonitoringTasks.value = monitoringTasks ?? []
     linkedTasksLoaded.value = true
   } catch (error) {
     if (requestId !== linkedTasksRequestId) return
     console.error('Error fetching linked datastream tasks', error)
     linkedTasksErrored.value = true
-    linkedTasksByDatastreamId.value = {}
-    monitoringTasksByDatastreamId.value = {}
+    rawEtlTasks.value = []
+    rawDataProductTasks.value = []
+    rawMonitoringTasks.value = []
   }
 }
 
+const linkedTasksByDatastreamId = computed<
+  Record<string, LinkedDatastreamTask[]>
+>(() => {
+  if (!linkedTasksLoaded.value) return {}
+  const datastreamIds = new Set(items.value.map((d) => String(d.id)))
+  const grouped: Record<string, LinkedDatastreamTask[]> = {}
+  const seen = new Set<string>()
+
+  for (const task of rawEtlTasks.value) {
+    for (const mapping of (task as any).mappings ?? []) {
+      const datastreamId = targetDatastreamId(mapping)
+      if (!datastreamId || !datastreamIds.has(String(datastreamId))) continue
+      addLinkedTask(grouped, seen, String(datastreamId), task, {
+        label: 'Fed by',
+        icon: mdiLightningBolt,
+        iconClass: 'datastream-task-link__icon--source',
+        route: routeForIngestionTask(task),
+      })
+    }
+  }
+
+  for (const task of rawDataProductTasks.value) {
+    const transformationGroups = [
+      {
+        label: 'Aggregated by',
+        icon: mdiCallMerge,
+        iconClass: 'datastream-task-link__icon--aggregation',
+        transformations: (task as any).aggregationTransformations ?? [],
+      },
+      {
+        label: 'Derived by',
+        icon: mdiSigma,
+        iconClass: 'datastream-task-link__icon--derived',
+        transformations: [
+          ...((task as any).compositeExpressionTransformations ?? []),
+          ...((task as any).expressionTransformations ?? []),
+        ],
+      },
+      {
+        label: 'Rating curve',
+        icon: mdiChartBellCurve,
+        iconClass: 'datastream-task-link__icon--rating-curve',
+        transformations: (task as any).ratingCurveTransformations ?? [],
+      },
+    ]
+    for (const group of transformationGroups) {
+      for (const transformation of group.transformations) {
+        const datastreamId = outputDatastreamId(transformation)
+        if (!datastreamId || !datastreamIds.has(String(datastreamId))) continue
+        addLinkedTask(grouped, seen, String(datastreamId), task, {
+          label: group.label,
+          icon: group.icon,
+          iconClass: group.iconClass,
+          route: routeForDataProductTask(task),
+        })
+      }
+    }
+  }
+
+  return grouped
+})
+
+const monitoringTasksByDatastreamId = computed<
+  Record<string, LinkedMonitoringTask[]>
+>(() => {
+  if (!linkedTasksLoaded.value) return {}
+  const datastreamIds = new Set(items.value.map((d) => String(d.id)))
+  const groupedMonitoring: Record<string, LinkedMonitoringTask[]> = {}
+  const seenMonitoring = new Set<string>()
+
+  for (const task of rawMonitoringTasks.value) {
+    const monitoredDatastreams = (task as any).monitoredDatastreams ?? []
+    for (const monitoredDatastream of monitoredDatastreams) {
+      const datastreamId = monitoredDatastreamId(monitoredDatastream)
+      if (!datastreamId || !datastreamIds.has(String(datastreamId))) continue
+
+      const key = `${datastreamId}:${(task as any).id}`
+      if (seenMonitoring.has(key)) continue
+      seenMonitoring.add(key)
+      groupedMonitoring[String(datastreamId)] ??= []
+      groupedMonitoring[String(datastreamId)].push({
+        id: String((task as any).id),
+        name: (task as any).name,
+        dataConnectionName: null,
+        displayName: truncateTaskInfoPart(
+          (task as any).name || (task as any).id
+        ),
+        label: 'Quality monitoring',
+        icon: mdiShieldCheckOutline,
+        iconClass: 'datastream-task-link__icon--monitoring',
+        status: getTaskStatusText(task),
+        paused: taskPaused(task),
+        lastRunAt:
+          (task as any).latestRun?.startedAt ??
+          (task as any).latestRun?.finishedAt ??
+          null,
+        route: routeForMonitoringTask(task),
+        ruleCount: ((monitoredDatastream as any).rules ?? []).length,
+        violationCount: monitoringViolationCount(
+          task,
+          String(datastreamId),
+          monitoredDatastreams.length
+        ),
+        latestRunStatus: (task as any).latestRun?.status ?? null,
+        lastRunStatus: getTaskRunStatusText((task as any).latestRun),
+      })
+    }
+  }
+
+  return groupedMonitoring
+})
+
 watch(
-  [
-    () => props.workspace.id,
-    canViewOrchestrationInfo,
-    thingIdRef,
-    () => items.value.map((d) => d.id).join(','),
-  ],
+  [() => props.workspace.id, canViewOrchestrationInfo, thingIdRef],
   () => {
     void loadLinkedTasks()
   },

--- a/apps/data-management/src/components/Datastream/DatastreamTable.vue
+++ b/apps/data-management/src/components/Datastream/DatastreamTable.vue
@@ -148,6 +148,84 @@
               <span>{{ item.valueCount }}</span>
             </p>
           </div>
+          <div
+            v-if="canViewOrchestrationInfo && linkedTasksLoaded"
+            class="datastream-task-link"
+            :class="datastreamTaskLinkClass(item.id)"
+          >
+            <v-icon
+              :class="[
+                'datastream-task-link__icon',
+                linkedTasksForDatastream(item.id).length === 1
+                  ? linkedTasksForDatastream(item.id)[0].iconClass
+                  : '',
+              ]"
+              :icon="
+                !linkedTasksForDatastream(item.id).length
+                  ? mdiLinkOff
+                  : linkedTasksForDatastream(item.id).length > 1
+                  ? mdiAlertOctagon
+                  : linkedTasksForDatastream(item.id)[0].icon
+              "
+              size="20"
+            />
+            <div class="datastream-task-link__body">
+              <div class="datastream-task-link__meta">
+                <span class="datastream-task-link__label">
+                  {{
+                    linkedTasksForDatastream(item.id).length > 1
+                      ? 'Multiple task targets'
+                      : linkedTasksForDatastream(item.id).length === 1
+                      ? linkedTasksForDatastream(item.id)[0].label
+                      : 'No task connected'
+                  }}
+                </span>
+                <template v-if="linkedTasksForDatastream(item.id).length === 1">
+                  <RouterLink
+                    class="datastream-task-link__name"
+                    :to="linkedTasksForDatastream(item.id)[0].route"
+                  >
+                    {{ linkedTasksForDatastream(item.id)[0].name }}
+                  </RouterLink>
+                  <TaskStatus
+                    :status="linkedTasksForDatastream(item.id)[0].status"
+                    :paused="linkedTasksForDatastream(item.id)[0].paused"
+                  />
+                </template>
+                <span v-else class="datastream-task-link__conflict-text">
+                  {{
+                    linkedTasksForDatastream(item.id).length > 1
+                      ? `${
+                          linkedTasksForDatastream(item.id).length
+                        } tasks are feeding this datastream.`
+                      : 'No task is feeding this datastream.'
+                  }}
+                </span>
+              </div>
+              <div
+                v-if="linkedTasksForDatastream(item.id).length > 1"
+                class="datastream-task-link__tasks"
+              >
+                <RouterLink
+                  v-for="task in linkedTasksForDatastream(item.id)"
+                  :key="task.id"
+                  :to="task.route"
+                >
+                  {{ task.name }}
+                </RouterLink>
+              </div>
+            </div>
+            <v-btn
+              v-if="linkedTasksForDatastream(item.id).length === 1"
+              size="small"
+              variant="text"
+              color="primary"
+              :append-icon="mdiChevronRight"
+              :to="linkedTasksForDatastream(item.id)[0].route"
+            >
+              Manage
+            </v-btn>
+          </div>
         </div>
         <div class="datastream-card__actions">
           <div class="datastream-card__icons">
@@ -342,212 +420,121 @@
       :style="{ 'max-height': `100vh` }"
       fixed-header
     >
-      <template v-slot:item.latest="{ item }">
-        <div class="datastream-latest">
-          <div class="datastream-title">
-            {{ item.name || item.OPName }}
-          </div>
-          <div class="mt-2">
-            <div
-              v-if="
-                !hasPermission(
-                  PermissionResource.Datastream,
-                  PermissionAction.View,
-                  workspace
-                ) && !item.isVisible
-              "
-              class="text-body-2"
-            >
-              Data is private for this datastream
-            </div>
-            <div v-else>
-              <Sparkline
-                class="mt-1"
-                :datastream="item"
-                @openChart="openCharts[item.id] = true"
-                @latest-value="(value) => handleLatestValueUpdate(item.id, value)"
-                :unitName="item.unitName"
-              />
-              <div
-                v-if="Number(item.valueCount) > 0"
-                class="mt-1 text-base leading-[1.3]"
-                :class="latestStatusClass(item)"
-              >
-                <strong class="mr-2 font-semibold">Latest observation:</strong>
-                <span class="font-semibold">{{ item.endDate }}</span>
+      <template v-slot:item="{ item }">
+        <tr class="datastream-table-row">
+          <td class="datastream-table-cell datastream-table-cell--latest">
+            <div class="datastream-latest">
+              <div class="datastream-title">
+                {{ item.name || item.OPName }}
               </div>
-              <div
-                v-if="shouldShowLatestValue(item.id)"
-                class="mt-1 text-base leading-[1.3]"
-                :class="latestStatusClass(item)"
-              >
-                <strong class="mr-2 font-semibold">Latest value:</strong>
-                <span class="font-semibold">{{ latestValueDisplay(item) }}</span>
-              </div>
-            </div>
-          </div>
-
-          <v-dialog v-model="openCharts[item.id]" width="80rem">
-            <DatastreamPopupPlot
-              :datastream="item"
-              @close="openCharts[item.id] = false"
-            />
-          </v-dialog>
-        </div>
-      </template>
-
-      <template v-slot:item.info="{ item }">
-        <div class="datastream-info-list">
-          <p class="datastream-line">
-            <strong class="mr-2">Identifier:</strong>
-            <span class="datastream-id">
-              {{ item.id }}
-              <v-tooltip text="Copy ID">
-                <template #activator="{ props }">
-                  <v-btn
-                    v-bind="props"
-                    icon
-                    size="small"
-                    variant="text"
-                    @click.stop="copyDatastreamId(item.id)"
+              <div class="mt-2">
+                <div
+                  v-if="
+                    !hasPermission(
+                      PermissionResource.Datastream,
+                      PermissionAction.View,
+                      workspace
+                    ) && !item.isVisible
+                  "
+                  class="text-body-2"
+                >
+                  Data is private for this datastream
+                </div>
+                <div v-else>
+                  <Sparkline
+                    class="mt-1"
+                    :datastream="item"
+                    @openChart="openCharts[item.id] = true"
+                    @latest-value="
+                      (value) => handleLatestValueUpdate(item.id, value)
+                    "
+                    :unitName="item.unitName"
+                  />
+                  <div
+                    v-if="Number(item.valueCount) > 0"
+                    class="mt-1 text-base leading-[1.3]"
+                    :class="latestStatusClass(item)"
                   >
-                    <v-icon :icon="mdiContentCopy" size="small" />
-                  </v-btn>
-                </template>
-              </v-tooltip>
-            </span>
-          </p>
-          <p class="datastream-line">
-            <strong class="mr-2">Sampled medium:</strong>
-            <span>{{ item.sampledMedium }}</span>
-          </p>
-          <p class="datastream-line">
-            <strong class="mr-2">Method:</strong>
-            <span>{{ item.sensorName }}</span>
-          </p>
-          <p class="datastream-line">
-            <strong class="mr-2">No data value:</strong>
-            <span>{{ item.noDataValue }}</span>
-          </p>
-          <p class="datastream-line">
-            <strong class="mr-2">Begin date:</strong>
-            <span>{{ item.beginDate }}</span>
-          </p>
-          <p class="datastream-line">
-            <strong class="mr-2">End date:</strong>
-            <span>{{ item.endDate }}</span>
-          </p>
-          <p class="datastream-line">
-            <strong class="mr-2">Number of observations:</strong>
-            <span>{{ item.valueCount }}</span>
-          </p>
-        </div>
-      </template>
+                    <strong class="mr-2 font-semibold"
+                      >Latest observation:</strong
+                    >
+                    <span class="font-semibold">{{ item.endDate }}</span>
+                  </div>
+                  <div
+                    v-if="shouldShowLatestValue(item.id)"
+                    class="mt-1 text-base leading-[1.3]"
+                    :class="latestStatusClass(item)"
+                  >
+                    <strong class="mr-2 font-semibold">Latest value:</strong>
+                    <span class="font-semibold">{{
+                      latestValueDisplay(item)
+                    }}</span>
+                  </div>
+                </div>
+              </div>
 
-      <template v-slot:item.actions="{ item }">
-        <div class="datastream-actions">
-          <div class="datastream-actions__icons">
-            <v-tooltip
-              bottom
-              :openDelay="500"
-              content-class="pa-0 ma-0 bg-transparent"
-              v-if="
-                hasPermission(
-                  PermissionResource.Datastream,
-                  PermissionAction.Edit,
-                  workspace
-                )
-              "
-            >
-              <template #activator="{ props: tp }">
-                <v-icon
-                  v-bind="tp"
-                  :icon="item.isVisible ? mdiFileEyeOutline : mdiFileRemove"
-                  :color="item.isVisible ? 'green' : 'red-darken-2'"
-                  :data-testid="`data-visibility-toggle-${item.id}`"
-                  small
-                  @click="toggleDataVisibility(item)"
+              <v-dialog v-model="openCharts[item.id]" width="80rem">
+                <DatastreamPopupPlot
+                  :datastream="item"
+                  @close="openCharts[item.id] = false"
                 />
-              </template>
-
-              <VisibilityTooltipCard
-                title="Observations are currently"
-                :items="[
-                  {
-                    label: 'Clicking this will',
-                    value: item.isVisible
-                      ? 'Hide data for this datastream from guests of your site while keeping the datastream metadata publicly visible.'
-                      : 'Make the observations and metadata for this datastream visible to guests of your site.',
-                  },
-                ]"
-                :is-visible="item.isVisible"
-              />
-            </v-tooltip>
-
-            <v-tooltip
-              bottom
-              :openDelay="500"
-              v-if="
-                hasPermission(
-                  PermissionResource.Datastream,
-                  PermissionAction.Edit,
-                  workspace
-                )
-              "
-              content-class="pa-0 ma-0 bg-transparent"
-            >
-              <template v-slot:activator="{ props }">
-                <v-icon
-                  :icon="item.isPrivate ? mdiLock : mdiLockOpenVariant"
-                  :color="item.isPrivate ? 'red-darken-2' : 'green'"
-                  :data-testid="`datastream-privacy-toggle-${item.id}`"
-                  small
-                  v-bind="props"
-                  @click="toggleVisibility(item)"
-                />
-              </template>
-
-              <VisibilityTooltipCard
-                title="Datastream is currently"
-                :items="[
-                  {
-                    label: 'Clicking this will',
-                    value: item.isPrivate
-                      ? 'Make this datastream and all its metadata and observations publicly visible.'
-                      : 'Hide this datastream from guests of your site along with all its metadata and observations.',
-                  },
-                ]"
-                :is-visible="!item.isPrivate"
-              />
-            </v-tooltip>
-
-            <v-tooltip
-              v-if="
-                !hasPermission(
-                  PermissionResource.Datastream,
-                  PermissionAction.View,
-                  workspace
-                ) && !item.isVisible
-              "
-              bottom
-              :openDelay="100"
-            >
-              <template v-slot:activator="{ props }">
-                <v-icon v-bind="props" :icon="mdiLock" color="red-darken-2" />
-              </template>
-              <span>The data for this datastream is private </span>
-            </v-tooltip>
-
-            <v-menu v-else>
-              <template v-slot:activator="{ props }">
-                <v-icon
-                  v-bind="props"
-                  :icon="mdiDotsVertical"
-                  :data-testid="`datastream-actions-${item.id}`"
-                />
-              </template>
-              <v-list>
-                <v-list-item
+              </v-dialog>
+            </div>
+          </td>
+          <td class="datastream-table-cell datastream-table-cell--info">
+            <div class="datastream-info-list">
+              <p class="datastream-line">
+                <strong class="mr-2">Identifier:</strong>
+                <span class="datastream-id">
+                  {{ item.id }}
+                  <v-tooltip text="Copy ID">
+                    <template #activator="{ props }">
+                      <v-btn
+                        v-bind="props"
+                        icon
+                        size="small"
+                        variant="text"
+                        @click.stop="copyDatastreamId(item.id)"
+                      >
+                        <v-icon :icon="mdiContentCopy" size="small" />
+                      </v-btn>
+                    </template>
+                  </v-tooltip>
+                </span>
+              </p>
+              <p class="datastream-line">
+                <strong class="mr-2">Sampled medium:</strong>
+                <span>{{ item.sampledMedium }}</span>
+              </p>
+              <p class="datastream-line">
+                <strong class="mr-2">Method:</strong>
+                <span>{{ item.sensorName }}</span>
+              </p>
+              <p class="datastream-line">
+                <strong class="mr-2">No data value:</strong>
+                <span>{{ item.noDataValue }}</span>
+              </p>
+              <p class="datastream-line">
+                <strong class="mr-2">Begin date:</strong>
+                <span>{{ item.beginDate }}</span>
+              </p>
+              <p class="datastream-line">
+                <strong class="mr-2">End date:</strong>
+                <span>{{ item.endDate }}</span>
+              </p>
+              <p class="datastream-line">
+                <strong class="mr-2">Number of observations:</strong>
+                <span>{{ item.valueCount }}</span>
+              </p>
+            </div>
+          </td>
+          <td class="datastream-table-cell datastream-table-cell--actions">
+            <div class="datastream-actions">
+              <div class="datastream-actions__icons">
+                <v-tooltip
+                  bottom
+                  :openDelay="500"
+                  content-class="pa-0 ma-0 bg-transparent"
                   v-if="
                     hasPermission(
                       PermissionResource.Datastream,
@@ -555,76 +542,265 @@
                       workspace
                     )
                   "
-                  :prepend-icon="mdiPencil"
-                  title="Edit datastream metadata"
-                  :data-testid="`edit-datastream-${item.id}`"
-                  @click="openDialog(item, 'edit')"
-                />
-                <div
+                >
+                  <template #activator="{ props: tp }">
+                    <v-icon
+                      v-bind="tp"
+                      :icon="item.isVisible ? mdiFileEyeOutline : mdiFileRemove"
+                      :color="item.isVisible ? 'green' : 'red-darken-2'"
+                      :data-testid="`data-visibility-toggle-${item.id}`"
+                      small
+                      @click="toggleDataVisibility(item)"
+                    />
+                  </template>
+
+                  <VisibilityTooltipCard
+                    title="Observations are currently"
+                    :items="[
+                      {
+                        label: 'Clicking this will',
+                        value: item.isVisible
+                          ? 'Hide data for this datastream from guests of your site while keeping the datastream metadata publicly visible.'
+                          : 'Make the observations and metadata for this datastream visible to guests of your site.',
+                      },
+                    ]"
+                    :is-visible="item.isVisible"
+                  />
+                </v-tooltip>
+
+                <v-tooltip
+                  bottom
+                  :openDelay="500"
                   v-if="
                     hasPermission(
                       PermissionResource.Datastream,
-                      PermissionAction.Delete,
+                      PermissionAction.Edit,
                       workspace
                     )
                   "
+                  content-class="pa-0 ma-0 bg-transparent"
                 >
-                  <v-list-item
-                    :prepend-icon="mdiDelete"
-                    title="Delete datastream"
-                    :data-testid="`delete-datastream-${item.id}`"
-                    @click="openDialog(item, 'delete')"
+                  <template v-slot:activator="{ props }">
+                    <v-icon
+                      :icon="item.isPrivate ? mdiLock : mdiLockOpenVariant"
+                      :color="item.isPrivate ? 'red-darken-2' : 'green'"
+                      :data-testid="`datastream-privacy-toggle-${item.id}`"
+                      small
+                      v-bind="props"
+                      @click="toggleVisibility(item)"
+                    />
+                  </template>
+
+                  <VisibilityTooltipCard
+                    title="Datastream is currently"
+                    :items="[
+                      {
+                        label: 'Clicking this will',
+                        value: item.isPrivate
+                          ? 'Make this datastream and all its metadata and observations publicly visible.'
+                          : 'Hide this datastream from guests of your site along with all its metadata and observations.',
+                      },
+                    ]"
+                    :is-visible="!item.isPrivate"
                   />
-                </div>
-                <v-list-item
+                </v-tooltip>
+
+                <v-tooltip
                   v-if="
-                    hasPermission(
-                      PermissionResource.Observation,
-                      PermissionAction.Delete,
+                    !hasPermission(
+                      PermissionResource.Datastream,
+                      PermissionAction.View,
                       workspace
-                    )
+                    ) && !item.isVisible
                   "
-                  :prepend-icon="mdiDeleteOutline"
-                  title="Delete data from datastream"
-                  :data-testid="`delete-datastream-data-${item.id}`"
-                  @click="openObservationDialog(item)"
+                  bottom
+                  :openDelay="100"
+                >
+                  <template v-slot:activator="{ props }">
+                    <v-icon
+                      v-bind="props"
+                      :icon="mdiLock"
+                      color="red-darken-2"
+                    />
+                  </template>
+                  <span>The data for this datastream is private </span>
+                </v-tooltip>
+
+                <v-menu v-else>
+                  <template v-slot:activator="{ props }">
+                    <v-icon
+                      v-bind="props"
+                      :icon="mdiDotsVertical"
+                      :data-testid="`datastream-actions-${item.id}`"
+                    />
+                  </template>
+                  <v-list>
+                    <v-list-item
+                      v-if="
+                        hasPermission(
+                          PermissionResource.Datastream,
+                          PermissionAction.Edit,
+                          workspace
+                        )
+                      "
+                      :prepend-icon="mdiPencil"
+                      title="Edit datastream metadata"
+                      :data-testid="`edit-datastream-${item.id}`"
+                      @click="openDialog(item, 'edit')"
+                    />
+                    <div
+                      v-if="
+                        hasPermission(
+                          PermissionResource.Datastream,
+                          PermissionAction.Delete,
+                          workspace
+                        )
+                      "
+                    >
+                      <v-list-item
+                        :prepend-icon="mdiDelete"
+                        title="Delete datastream"
+                        :data-testid="`delete-datastream-${item.id}`"
+                        @click="openDialog(item, 'delete')"
+                      />
+                    </div>
+                    <v-list-item
+                      v-if="
+                        hasPermission(
+                          PermissionResource.Observation,
+                          PermissionAction.Delete,
+                          workspace
+                        )
+                      "
+                      :prepend-icon="mdiDeleteOutline"
+                      title="Delete data from datastream"
+                      :data-testid="`delete-datastream-data-${item.id}`"
+                      @click="openObservationDialog(item)"
+                    />
+                    <v-list-item
+                      :prepend-icon="mdiChartLine"
+                      title="Visualize data"
+                      :data-testid="`visualize-datastream-${item.id}`"
+                      :to="{
+                        name: 'VisualizeData',
+                        query: { sites: item.thingId, datastreams: item.id },
+                      }"
+                    />
+                    <v-list-item
+                      :prepend-icon="mdiDownload"
+                      title="Download data"
+                      :data-testid="`download-datastream-${item.id}`"
+                      @click="onDownload(item.id)"
+                    />
+                  </v-list>
+                </v-menu>
+              </div>
+              <v-btn
+                variant="outlined"
+                class="mt-2 datastream-meta-btn"
+                :data-testid="`datastream-metadata-${item.id}`"
+                @click="openInfoCardFor(item)"
+              >
+                View Full Metadata
+              </v-btn>
+              <div v-if="downloading[item.id]" class="datastream-download mt-2">
+                <v-progress-circular
+                  indeterminate
+                  size="16"
+                  width="2"
+                  color="primary"
                 />
-                <v-list-item
-                  :prepend-icon="mdiChartLine"
-                  title="Visualize data"
-                  :data-testid="`visualize-datastream-${item.id}`"
-                  :to="{
-                    name: 'VisualizeData',
-                    query: { sites: item.thingId, datastreams: item.id },
-                  }"
-                />
-                <v-list-item
-                  :prepend-icon="mdiDownload"
-                  title="Download data"
-                  :data-testid="`download-datastream-${item.id}`"
-                  @click="onDownload(item.id)"
-                />
-              </v-list>
-            </v-menu>
-          </div>
-          <v-btn
-            variant="outlined"
-            class="mt-2 datastream-meta-btn"
-            :data-testid="`datastream-metadata-${item.id}`"
-            @click="openInfoCardFor(item)"
-          >
-            View Full Metadata
-          </v-btn>
-          <div v-if="downloading[item.id]" class="datastream-download mt-2">
-            <v-progress-circular
-              indeterminate
-              size="16"
-              width="2"
-              color="primary"
-            />
-            preparing file...
-          </div>
-        </div>
+                preparing file...
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr
+          v-if="canViewOrchestrationInfo && linkedTasksLoaded"
+          class="datastream-task-row"
+        >
+          <td :colspan="headers.length" class="datastream-task-row__cell">
+            <div
+              class="datastream-task-link datastream-task-link--table"
+              :class="datastreamTaskLinkClass(item.id)"
+            >
+              <v-icon
+                :class="[
+                  'datastream-task-link__icon',
+                  linkedTasksForDatastream(item.id).length === 1
+                    ? linkedTasksForDatastream(item.id)[0].iconClass
+                    : '',
+                ]"
+                :icon="
+                  !linkedTasksForDatastream(item.id).length
+                    ? mdiLinkOff
+                    : linkedTasksForDatastream(item.id).length > 1
+                    ? mdiAlertOctagon
+                    : linkedTasksForDatastream(item.id)[0].icon
+                "
+                size="20"
+              />
+              <div class="datastream-task-link__body">
+                <div class="datastream-task-link__meta">
+                  <span class="datastream-task-link__label">
+                    {{
+                      linkedTasksForDatastream(item.id).length > 1
+                        ? 'Multiple task targets'
+                        : linkedTasksForDatastream(item.id).length === 1
+                        ? linkedTasksForDatastream(item.id)[0].label
+                        : 'No task connected'
+                    }}
+                  </span>
+                  <template
+                    v-if="linkedTasksForDatastream(item.id).length === 1"
+                  >
+                    <RouterLink
+                      class="datastream-task-link__name"
+                      :to="linkedTasksForDatastream(item.id)[0].route"
+                    >
+                      {{ linkedTasksForDatastream(item.id)[0].name }}
+                    </RouterLink>
+                    <TaskStatus
+                      :status="linkedTasksForDatastream(item.id)[0].status"
+                      :paused="linkedTasksForDatastream(item.id)[0].paused"
+                    />
+                  </template>
+                  <span v-else class="datastream-task-link__conflict-text">
+                    {{
+                      linkedTasksForDatastream(item.id).length > 1
+                        ? `${
+                            linkedTasksForDatastream(item.id).length
+                          } tasks are feeding this datastream.`
+                        : 'No task is feeding this datastream.'
+                    }}
+                  </span>
+                </div>
+                <div
+                  v-if="linkedTasksForDatastream(item.id).length > 1"
+                  class="datastream-task-link__tasks"
+                >
+                  <RouterLink
+                    v-for="task in linkedTasksForDatastream(item.id)"
+                    :key="task.id"
+                    :to="task.route"
+                  >
+                    {{ task.name }}
+                  </RouterLink>
+                </div>
+              </div>
+              <v-btn
+                v-if="linkedTasksForDatastream(item.id).length === 1"
+                size="small"
+                variant="text"
+                color="primary"
+                :append-icon="mdiChevronRight"
+                :to="linkedTasksForDatastream(item.id)[0].route"
+              >
+                Manage
+              </v-btn>
+            </div>
+          </td>
+        </tr>
       </template>
     </v-data-table-virtual>
   </v-card>
@@ -682,23 +858,29 @@ import DatastreamPopupPlot from '@/components/Datastream/DatastreamPopupPlot.vue
 import DatastreamForm from '@/components/Datastream/DatastreamForm.vue'
 import DatastreamDeleteCard from './DatastreamDeleteCard.vue'
 import Sparkline from '@/components/Sparkline.vue'
-import { computed, reactive, ref, toRef } from 'vue'
+import TaskStatus from '@/components/Orchestration/shared/TaskStatus.vue'
+import { computed, reactive, ref, toRef, watch } from 'vue'
 import { useMetadata } from '@/composables/useMetadata'
 import { storeToRefs } from 'pinia'
 import { useThingStore } from '@/store/thing'
-import { Datastream, Workspace } from '@hydroserver/client'
+import { Datastream, Workspace, type StatusType } from '@hydroserver/client'
 import { useWorkspacePermissions } from '@/composables/useWorkspacePermissions'
 import { useTableLogic } from '@/composables/useTableLogic'
 import { Snackbar } from '@/utils/notifications'
 import { downloadDatastreamCsv } from '@/utils/csvExport'
 import { formatTime } from '@/utils/time'
+import { getTaskStatusText } from '@/utils/orchestration/taskRunDetails'
 import DatastreamTableInfoCard from './DatastreamTableInfoCard.vue'
 import ObservationsDeleteCard from '../Observation/ObservationsDeleteCard.vue'
 import VisibilityTooltipCard from '@/components/Datastream/VisibilityTooltipCard.vue'
 import hs, { PermissionAction, PermissionResource } from '@hydroserver/client'
 import { useDisplay } from 'vuetify/lib/framework.mjs'
 import {
+  mdiAlertOctagon,
+  mdiCallMerge,
+  mdiChartBellCurve,
   mdiChartLine,
+  mdiChevronRight,
   mdiContentCopy,
   mdiDelete,
   mdiDeleteOutline,
@@ -706,16 +888,34 @@ import {
   mdiDownload,
   mdiFileEyeOutline,
   mdiFileRemove,
+  mdiLightningBolt,
+  mdiLinkOff,
   mdiLock,
   mdiLockOpenVariant,
   mdiMagnify,
   mdiPencil,
   mdiPlus,
+  mdiSigma,
 } from '@mdi/js'
 
 const props = defineProps({
   workspace: { type: Object as () => Workspace, required: true },
 })
+
+type LinkedDatastreamTask = {
+  id: string
+  name: string
+  label: string
+  icon: string
+  iconClass: string
+  status: StatusType
+  paused: boolean
+  route: {
+    name: string
+    params: { view: string }
+    query: Record<string, string>
+  }
+}
 
 const { thing } = storeToRefs(useThingStore())
 const openCreate = ref(false)
@@ -739,7 +939,23 @@ const openInfoCardFor = (datastream: Datastream) => {
   openInfoCard.value = true
 }
 
-const { hasPermission } = useWorkspacePermissions(workspaceRef)
+const { hasPermission, isAdmin, isOwner } =
+  useWorkspacePermissions(workspaceRef)
+
+const canViewOrchestrationInfo = computed(() => {
+  const workspace = props.workspace
+  const roleName = `${workspace.collaboratorRole?.name ?? ''}`.toLowerCase()
+  return (
+    isAdmin() ||
+    isOwner(workspace) ||
+    roleName === 'editor' ||
+    hasPermission(
+      PermissionResource.Workspace,
+      PermissionAction.Edit,
+      workspace
+    )
+  )
+})
 
 const updateDatastream = async (updatedDatastream: Datastream) => {
   await fetchMetadata(props.workspace.id)
@@ -767,6 +983,11 @@ const openCharts = reactive<Record<string, boolean>>({})
 const latestValues = reactive<
   Record<string, { text: string; showUnit: boolean; isBad: boolean }>
 >({})
+const linkedTasksByDatastreamId = ref<Record<string, LinkedDatastreamTask[]>>(
+  {}
+)
+const linkedTasksLoaded = ref(false)
+let linkedTasksRequestId = 0
 
 const handleLatestValueUpdate = (
   datastreamId: string,
@@ -877,6 +1098,213 @@ const mobileDatastreams = computed(() => {
     (item.searchText || '').includes(normalizedSearch.value)
   )
 })
+
+const linkedTasksForDatastream = (datastreamId: string) =>
+  linkedTasksByDatastreamId.value[datastreamId] ?? []
+
+const datastreamTaskLinkClass = (datastreamId: string) => {
+  const linkedTasks = linkedTasksForDatastream(datastreamId)
+  if (!linkedTasks.length) return 'datastream-task-link--none'
+  if (linkedTasks.length > 1) return 'datastream-task-link--conflict'
+  if (linkedTasks[0].paused) return 'datastream-task-link--none'
+
+  const statusClass: Record<StatusType, string> = {
+    OK: 'datastream-task-link--ok',
+    Pending: 'datastream-task-link--pending',
+    'Needs attention': 'datastream-task-link--attention',
+    'Behind schedule': 'datastream-task-link--behind',
+    Unknown: 'datastream-task-link--none',
+    'Loading paused': 'datastream-task-link--none',
+  }
+  return statusClass[linkedTasks[0].status]
+}
+
+const routeForIngestionTask = (task: any) => {
+  const query: Record<string, string> = {
+    workspace_id: props.workspace.id,
+    task_id: String(task.id),
+  }
+  const dataConnectionId = task.dataConnection?.id ?? task.dataConnectionId
+  if (dataConnectionId) query.data_connection_id = String(dataConnectionId)
+
+  return {
+    name: 'OrchestrationIngestionDetails',
+    params: { view: 'ingestion' },
+    query,
+  }
+}
+
+const dataProductRouteName = (task: any) => {
+  if (task.aggregationTransformations?.length) {
+    return 'OrchestrationAggregationDetails'
+  }
+  if (task.expressionTransformations?.length) {
+    return 'OrchestrationExpressionDetails'
+  }
+  if (task.compositeExpressionTransformations?.length) {
+    return 'OrchestrationDerivationDetails'
+  }
+  if (task.ratingCurveTransformations?.length) {
+    return 'OrchestrationRatingCurveDetails'
+  }
+  return 'OrchestrationAggregationDetails'
+}
+
+const routeForDataProductTask = (task: any) => {
+  const query: Record<string, string> = {
+    workspace_id: props.workspace.id,
+    task_id: String(task.id),
+  }
+  const siteId = task.thing?.id ?? task.thingId ?? thing.value?.id
+  if (siteId) query.site_id = String(siteId)
+
+  return {
+    name: dataProductRouteName(task),
+    params: { view: 'aggregation' },
+    query,
+  }
+}
+
+const outputDatastreamId = (transformation: any) =>
+  transformation?.outputDatastream?.id ?? transformation?.outputDatastreamId
+
+const targetDatastreamId = (mapping: any) =>
+  mapping?.targetDatastream?.id ?? mapping?.targetDatastreamId
+
+const taskPaused = (task: any) =>
+  task.schedule ? task.schedule.enabled === false : false
+
+const addLinkedTask = (
+  grouped: Record<string, LinkedDatastreamTask[]>,
+  seen: Set<string>,
+  datastreamId: string,
+  task: any,
+  config: Pick<LinkedDatastreamTask, 'label' | 'icon' | 'route'> &
+    Partial<Pick<LinkedDatastreamTask, 'iconClass'>>
+) => {
+  const key = `${datastreamId}:${task.id}`
+  if (seen.has(key)) return
+  seen.add(key)
+  grouped[datastreamId] ??= []
+  grouped[datastreamId].push({
+    id: String(task.id),
+    name: task.name,
+    label: config.label,
+    icon: config.icon,
+    iconClass: config.iconClass ?? '',
+    status: getTaskStatusText(task),
+    paused: taskPaused(task),
+    route: config.route,
+  })
+}
+
+const loadLinkedTasks = async () => {
+  const requestId = ++linkedTasksRequestId
+  linkedTasksLoaded.value = false
+  const site = thing.value
+  if (
+    !canViewOrchestrationInfo.value ||
+    !site ||
+    !props.workspace?.id ||
+    !items.value.length
+  ) {
+    linkedTasksByDatastreamId.value = {}
+    return
+  }
+
+  const datastreamIds = new Set(items.value.map((d) => String(d.id)))
+  try {
+    const [etlTasks, dataProductTasks] = await Promise.all([
+      hs.tasks.listAllItems({
+        workspace_id: [props.workspace.id],
+        order_by: ['name'],
+        expand_related: true,
+      } as any),
+      hs.dataProductTasks.listAllItems({
+        workspace_id: [props.workspace.id],
+        thing_id: [site.id],
+        order_by: ['name'],
+        expand_related: true,
+      } as any),
+    ])
+    if (requestId !== linkedTasksRequestId) return
+
+    const grouped: Record<string, LinkedDatastreamTask[]> = {}
+    const seen = new Set<string>()
+
+    for (const task of etlTasks ?? []) {
+      for (const mapping of (task as any).mappings ?? []) {
+        const datastreamId = targetDatastreamId(mapping)
+        if (!datastreamId || !datastreamIds.has(String(datastreamId))) continue
+        addLinkedTask(grouped, seen, String(datastreamId), task, {
+          label: 'Fed by',
+          icon: mdiLightningBolt,
+          iconClass: 'datastream-task-link__icon--source',
+          route: routeForIngestionTask(task),
+        })
+      }
+    }
+
+    for (const task of dataProductTasks ?? []) {
+      const transformationGroups = [
+        {
+          label: 'Aggregated by',
+          icon: mdiCallMerge,
+          iconClass: 'datastream-task-link__icon--aggregation',
+          transformations: (task as any).aggregationTransformations ?? [],
+        },
+        {
+          label: 'Derived by',
+          icon: mdiSigma,
+          iconClass: 'datastream-task-link__icon--derived',
+          transformations: [
+            ...((task as any).compositeExpressionTransformations ?? []),
+            ...((task as any).expressionTransformations ?? []),
+          ],
+        },
+        {
+          label: 'Rating curve',
+          icon: mdiChartBellCurve,
+          iconClass: 'datastream-task-link__icon--rating-curve',
+          transformations: (task as any).ratingCurveTransformations ?? [],
+        },
+      ]
+      for (const group of transformationGroups) {
+        for (const transformation of group.transformations) {
+          const datastreamId = outputDatastreamId(transformation)
+          if (!datastreamId || !datastreamIds.has(String(datastreamId)))
+            continue
+          addLinkedTask(grouped, seen, String(datastreamId), task, {
+            label: group.label,
+            icon: group.icon,
+            iconClass: group.iconClass,
+            route: routeForDataProductTask(task),
+          })
+        }
+      }
+    }
+
+    linkedTasksByDatastreamId.value = grouped
+    linkedTasksLoaded.value = true
+  } catch (error) {
+    if (requestId !== linkedTasksRequestId) return
+    console.error('Error fetching linked datastream tasks', error)
+    linkedTasksByDatastreamId.value = {}
+  }
+}
+
+watch(
+  [
+    () => props.workspace.id,
+    canViewOrchestrationInfo,
+    thingIdRef,
+    () => items.value.map((d) => d.id).join(','),
+  ],
+  () => {
+    void loadLinkedTasks()
+  },
+  { immediate: true }
+)
 
 const onDownload = async (datastreamId: string) => {
   if (downloading[datastreamId]) return
@@ -1169,6 +1597,129 @@ const loadDatastreams = async () => {
   align-items: center;
   gap: 0.5rem;
   font-size: 0.85rem;
+}
+
+.datastream-task-link {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  width: 100%;
+  margin-top: 0.75rem;
+  padding: 0.55rem 0.65rem;
+  border-left: 4px solid #757575;
+  border-radius: 6px;
+  background: #f5f5f5;
+  color: #424242;
+}
+
+.datastream-task-row__cell {
+  padding: 0 !important;
+  border-top: 0 !important;
+}
+
+.datastream-task-link--table {
+  margin-top: 0;
+  border-radius: 0;
+}
+
+.datastream-task-link--ok {
+  border-left-color: #2e7d32;
+  background: #f1f8f3;
+  color: #1f1d24;
+}
+
+.datastream-task-link--attention,
+.datastream-task-link--conflict {
+  border-left-color: #c62828;
+  background: #fff7f7;
+  color: #1f1d24;
+  box-shadow: inset 0 0 0 1px rgba(198, 40, 40, 0.1);
+}
+
+.datastream-task-link--pending {
+  border-left-color: #1976d2;
+  background: #eef6ff;
+  color: #1f1d24;
+}
+
+.datastream-task-link--behind {
+  border-left-color: #e65100;
+  background: #fff4e5;
+  color: #1f1d24;
+}
+
+.datastream-task-link--none {
+  border-left-color: #757575;
+  background: #f5f5f5;
+  color: #424242;
+}
+
+.datastream-task-link__icon--source {
+  color: #1976d2 !important;
+}
+
+.datastream-task-link__icon--derived {
+  color: #8e24aa !important;
+}
+
+.datastream-task-link__icon--aggregation {
+  color: #6a1b9a !important;
+}
+
+.datastream-task-link__icon--rating-curve {
+  color: #283593 !important;
+}
+
+.datastream-task-link__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.datastream-task-link__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.85rem;
+}
+
+.datastream-task-link__label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: currentColor;
+  opacity: 0.72;
+}
+
+.datastream-task-link__name {
+  color: inherit;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.datastream-task-link__name:hover,
+.datastream-task-link__tasks a:hover {
+  text-decoration: underline;
+}
+
+.datastream-task-link__conflict-text {
+  font-weight: 700;
+}
+
+.datastream-task-link__tasks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+}
+
+.datastream-task-link__tasks a {
+  color: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 @media (max-width: 960px) {

--- a/apps/data-management/src/components/Datastream/DatastreamTable.vue
+++ b/apps/data-management/src/components/Datastream/DatastreamTable.vue
@@ -244,6 +244,21 @@
               Manage
             </v-btn>
           </div>
+          <div
+            v-else-if="showTaskSkeleton"
+            class="datastream-task-link datastream-task-link--loading"
+            aria-label="Loading task information"
+          >
+            <span class="datastream-task-link__loading-icon" />
+            <div class="datastream-task-link__body">
+              <span
+                class="datastream-task-link__loading-bar datastream-task-link__loading-bar--label"
+              />
+              <span
+                class="datastream-task-link__loading-bar datastream-task-link__loading-bar--name"
+              />
+            </div>
+          </div>
         </div>
         <div class="datastream-card__actions">
           <div class="datastream-card__icons">
@@ -819,6 +834,21 @@
             Manage
           </v-btn>
         </div>
+        <div
+          v-else-if="showTaskSkeleton"
+          class="datastream-task-link datastream-task-link--card datastream-task-link--loading"
+          aria-label="Loading task information"
+        >
+          <span class="datastream-task-link__loading-icon" />
+          <div class="datastream-task-link__body">
+            <span
+              class="datastream-task-link__loading-bar datastream-task-link__loading-bar--label"
+            />
+            <span
+              class="datastream-task-link__loading-bar datastream-task-link__loading-bar--name"
+            />
+          </div>
+        </div>
       </div>
     </div>
   </v-card>
@@ -958,6 +988,7 @@ const datastreamTableRef = ref<{
   scrollToIndex?: (index: number) => void
 } | null>(null)
 const highlightedDatastreamId = ref('')
+const DATASTREAM_HIGHLIGHT_DURATION_MS = 2500
 let highlightTimeout: number | undefined
 const { smAndDown } = useDisplay()
 const isMobile = computed(() => smAndDown.value)
@@ -1014,6 +1045,7 @@ const linkedTasksByDatastreamId = ref<Record<string, LinkedDatastreamTask[]>>(
   {}
 )
 const linkedTasksLoaded = ref(false)
+const linkedTasksErrored = ref(false)
 let linkedTasksRequestId = 0
 
 const handleLatestValueUpdate = (
@@ -1160,7 +1192,7 @@ function highlightTargetDatastream() {
   if (highlightTimeout) window.clearTimeout(highlightTimeout)
   highlightTimeout = window.setTimeout(() => {
     highlightedDatastreamId.value = ''
-  }, 5000)
+  }, DATASTREAM_HIGHLIGHT_DURATION_MS)
 }
 
 async function scrollToTargetDatastream() {
@@ -1211,6 +1243,13 @@ const linkedTasksForDatastream = (datastreamId: string) =>
 
 const showTaskRow = computed(
   () => canViewOrchestrationInfo.value && linkedTasksLoaded.value
+)
+
+const showTaskSkeleton = computed(
+  () =>
+    canViewOrchestrationInfo.value &&
+    !linkedTasksLoaded.value &&
+    !linkedTasksErrored.value
 )
 
 const datastreamTaskLinkClass = (datastreamId: string) => {
@@ -1378,6 +1417,7 @@ const addLinkedTask = (
 const loadLinkedTasks = async () => {
   const requestId = ++linkedTasksRequestId
   linkedTasksLoaded.value = false
+  linkedTasksErrored.value = false
   const site = thing.value
   if (
     !canViewOrchestrationInfo.value ||
@@ -1466,6 +1506,7 @@ const loadLinkedTasks = async () => {
   } catch (error) {
     if (requestId !== linkedTasksRequestId) return
     console.error('Error fetching linked datastream tasks', error)
+    linkedTasksErrored.value = true
     linkedTasksByDatastreamId.value = {}
   }
 }
@@ -1884,6 +1925,47 @@ const loadDatastreams = async () => {
   color: rgba(0, 0, 0, 0.87);
 }
 
+.datastream-task-link--loading {
+  border-left-color: #90a4ae;
+  background: #f3f6f8;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.datastream-task-link__loading-icon,
+.datastream-task-link__loading-bar {
+  display: block;
+  flex: none;
+  border-radius: 999px;
+  background:
+    linear-gradient(
+      90deg,
+      rgba(120, 144, 156, 0.14) 0%,
+      rgba(120, 144, 156, 0.28) 42%,
+      rgba(120, 144, 156, 0.14) 82%
+    );
+  background-size: 220% 100%;
+  animation: datastream-task-skeleton 1.4s ease-in-out infinite;
+}
+
+.datastream-task-link__loading-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.datastream-task-link__loading-bar {
+  height: 0.48rem;
+}
+
+.datastream-task-link__loading-bar--label {
+  width: 8rem;
+  max-width: 38%;
+}
+
+.datastream-task-link__loading-bar--name {
+  width: 20rem;
+  max-width: 68%;
+}
+
 .datastream-task-link__icon--source {
   color: #2196f3 !important;
 }
@@ -1974,6 +2056,16 @@ const loadDatastreams = async () => {
   font-weight: 700;
   text-decoration: underline;
   text-underline-offset: 2px;
+}
+
+@keyframes datastream-task-skeleton {
+  0% {
+    background-position: 120% 0;
+  }
+
+  100% {
+    background-position: -120% 0;
+  }
 }
 
 @media (max-width: 960px) {

--- a/apps/data-management/src/components/Datastream/DatastreamTable.vue
+++ b/apps/data-management/src/components/Datastream/DatastreamTable.vue
@@ -1639,22 +1639,20 @@ const loadLinkedTasks = async () => {
   try {
     const [etlTasks, dataProductTasks, monitoringTasks] = await Promise.all([
       hs.tasks.listAllItems({
-        workspace_id: [props.workspace.id],
+        thing_id: [site.id],
         order_by: ['name'],
         expand_related: true,
-      } as any),
+      }),
       hs.dataProductTasks.listAllItems({
-        workspace_id: [props.workspace.id],
         thing_id: [site.id],
         order_by: ['name'],
         expand_related: true,
-      } as any),
+      }),
       hs.monitoringTasks.listAllItems({
-        workspace_id: [props.workspace.id],
         thing_id: [site.id],
         order_by: ['name'],
         expand_related: true,
-      } as any),
+      }),
     ])
     if (requestId !== linkedTasksRequestId) return
 

--- a/apps/data-management/src/components/Datastream/DatastreamTable.vue
+++ b/apps/data-management/src/components/Datastream/DatastreamTable.vue
@@ -3,7 +3,7 @@
     {{ thing!.dataDisclaimer }}
   </h6>
 
-  <v-card>
+  <v-card ref="datastreamSectionRef">
     <div class="datastream-toolbar">
       <div class="datastream-toolbar__left">
         <h5 class="text-h6 datastream-toolbar__title">
@@ -51,6 +51,10 @@
         v-for="item in mobileDatastreams"
         :key="item.id"
         class="datastream-card"
+        :class="{
+          'datastream-card--highlighted': isTargetDatastream(item.id),
+        }"
+        :data-datastream-id="item.id"
         variant="outlined"
       >
         <div class="datastream-card__content">
@@ -185,12 +189,26 @@
                     class="datastream-task-link__name"
                     :to="linkedTasksForDatastream(item.id)[0].route"
                   >
-                    {{ linkedTasksForDatastream(item.id)[0].name }}
+                    {{ linkedTasksForDatastream(item.id)[0].displayName }}
                   </RouterLink>
-                  <TaskStatus
-                    :status="linkedTasksForDatastream(item.id)[0].status"
-                    :paused="linkedTasksForDatastream(item.id)[0].paused"
-                  />
+                  <span
+                    class="datastream-task-link__status"
+                    :title="
+                      displayedTaskStatus(linkedTasksForDatastream(item.id)[0])
+                    "
+                  >
+                    <span
+                      class="datastream-task-link__dot"
+                      :style="{
+                        backgroundColor: taskStatusColor(
+                          linkedTasksForDatastream(item.id)[0]
+                        ),
+                      }"
+                    />
+                    <span class="datastream-task-link__last-ran">
+                      {{ lastRanLabel(linkedTasksForDatastream(item.id)[0]) }}
+                    </span>
+                  </span>
                 </template>
                 <span v-else class="datastream-task-link__conflict-text">
                   {{
@@ -198,7 +216,7 @@
                       ? `${
                           linkedTasksForDatastream(item.id).length
                         } tasks are feeding this datastream.`
-                      : 'No task is feeding this datastream.'
+                      : ''
                   }}
                 </span>
               </div>
@@ -211,7 +229,7 @@
                   :key="task.id"
                   :to="task.route"
                 >
-                  {{ task.name }}
+                  {{ task.displayName }}
                 </RouterLink>
               </div>
             </div>
@@ -410,399 +428,399 @@
       </v-card>
     </div>
 
-    <v-data-table-virtual
-      v-else
-      class="datastream-table"
-      :headers="headers"
-      :items="visibleDatastreams"
-      :search="search"
-      :sort-by="sortBy"
-      :style="{ 'max-height': `100vh` }"
-      fixed-header
-    >
-      <template v-slot:item="{ item }">
-        <tr class="datastream-table-row">
-          <td class="datastream-table-cell datastream-table-cell--latest">
-            <div class="datastream-latest">
-              <div class="datastream-title">
-                {{ item.name || item.OPName }}
-              </div>
-              <div class="mt-2">
-                <div
-                  v-if="
-                    !hasPermission(
-                      PermissionResource.Datastream,
-                      PermissionAction.View,
-                      workspace
-                    ) && !item.isVisible
-                  "
-                  class="text-body-2"
-                >
-                  Data is private for this datastream
-                </div>
-                <div v-else>
-                  <Sparkline
-                    class="mt-1"
-                    :datastream="item"
-                    @openChart="openCharts[item.id] = true"
-                    @latest-value="
-                      (value) => handleLatestValueUpdate(item.id, value)
-                    "
-                    :unitName="item.unitName"
-                  />
-                  <div
-                    v-if="Number(item.valueCount) > 0"
-                    class="mt-1 text-base leading-[1.3]"
-                    :class="latestStatusClass(item)"
-                  >
-                    <strong class="mr-2 font-semibold"
-                      >Latest observation:</strong
-                    >
-                    <span class="font-semibold">{{ item.endDate }}</span>
-                  </div>
-                  <div
-                    v-if="shouldShowLatestValue(item.id)"
-                    class="mt-1 text-base leading-[1.3]"
-                    :class="latestStatusClass(item)"
-                  >
-                    <strong class="mr-2 font-semibold">Latest value:</strong>
-                    <span class="font-semibold">{{
-                      latestValueDisplay(item)
-                    }}</span>
-                  </div>
-                </div>
-              </div>
+    <div v-else class="datastream-list">
+      <div class="datastream-list__head">
+        <span>Observation information</span>
+        <span>Datastream information</span>
+        <span class="datastream-list__head-actions">Actions</span>
+      </div>
 
-              <v-dialog v-model="openCharts[item.id]" width="80rem">
-                <DatastreamPopupPlot
-                  :datastream="item"
-                  @close="openCharts[item.id] = false"
-                />
-              </v-dialog>
+      <div
+        v-for="item in tableDatastreams"
+        :key="item.id"
+        class="ds-card"
+        :class="{ 'ds-card--highlighted': isTargetDatastream(item.id) }"
+        :data-datastream-id="item.id"
+      >
+        <div class="ds-card__grid">
+          <div class="datastream-latest">
+            <div class="datastream-title">
+              {{ item.name || item.OPName }}
             </div>
-          </td>
-          <td class="datastream-table-cell datastream-table-cell--info">
-            <div class="datastream-info-list">
-              <p class="datastream-line">
-                <strong class="mr-2">Identifier:</strong>
-                <span class="datastream-id">
-                  {{ item.id }}
-                  <v-tooltip text="Copy ID">
-                    <template #activator="{ props }">
-                      <v-btn
-                        v-bind="props"
-                        icon
-                        size="small"
-                        variant="text"
-                        @click.stop="copyDatastreamId(item.id)"
-                      >
-                        <v-icon :icon="mdiContentCopy" size="small" />
-                      </v-btn>
-                    </template>
-                  </v-tooltip>
-                </span>
-              </p>
-              <p class="datastream-line">
-                <strong class="mr-2">Sampled medium:</strong>
-                <span>{{ item.sampledMedium }}</span>
-              </p>
-              <p class="datastream-line">
-                <strong class="mr-2">Method:</strong>
-                <span>{{ item.sensorName }}</span>
-              </p>
-              <p class="datastream-line">
-                <strong class="mr-2">No data value:</strong>
-                <span>{{ item.noDataValue }}</span>
-              </p>
-              <p class="datastream-line">
-                <strong class="mr-2">Begin date:</strong>
-                <span>{{ item.beginDate }}</span>
-              </p>
-              <p class="datastream-line">
-                <strong class="mr-2">End date:</strong>
-                <span>{{ item.endDate }}</span>
-              </p>
-              <p class="datastream-line">
-                <strong class="mr-2">Number of observations:</strong>
-                <span>{{ item.valueCount }}</span>
-              </p>
-            </div>
-          </td>
-          <td class="datastream-table-cell datastream-table-cell--actions">
-            <div class="datastream-actions">
-              <div class="datastream-actions__icons">
-                <v-tooltip
-                  bottom
-                  :openDelay="500"
-                  content-class="pa-0 ma-0 bg-transparent"
-                  v-if="
-                    hasPermission(
-                      PermissionResource.Datastream,
-                      PermissionAction.Edit,
-                      workspace
-                    )
-                  "
-                >
-                  <template #activator="{ props: tp }">
-                    <v-icon
-                      v-bind="tp"
-                      :icon="item.isVisible ? mdiFileEyeOutline : mdiFileRemove"
-                      :color="item.isVisible ? 'green' : 'red-darken-2'"
-                      :data-testid="`data-visibility-toggle-${item.id}`"
-                      small
-                      @click="toggleDataVisibility(item)"
-                    />
-                  </template>
-
-                  <VisibilityTooltipCard
-                    title="Observations are currently"
-                    :items="[
-                      {
-                        label: 'Clicking this will',
-                        value: item.isVisible
-                          ? 'Hide data for this datastream from guests of your site while keeping the datastream metadata publicly visible.'
-                          : 'Make the observations and metadata for this datastream visible to guests of your site.',
-                      },
-                    ]"
-                    :is-visible="item.isVisible"
-                  />
-                </v-tooltip>
-
-                <v-tooltip
-                  bottom
-                  :openDelay="500"
-                  v-if="
-                    hasPermission(
-                      PermissionResource.Datastream,
-                      PermissionAction.Edit,
-                      workspace
-                    )
-                  "
-                  content-class="pa-0 ma-0 bg-transparent"
-                >
-                  <template v-slot:activator="{ props }">
-                    <v-icon
-                      :icon="item.isPrivate ? mdiLock : mdiLockOpenVariant"
-                      :color="item.isPrivate ? 'red-darken-2' : 'green'"
-                      :data-testid="`datastream-privacy-toggle-${item.id}`"
-                      small
-                      v-bind="props"
-                      @click="toggleVisibility(item)"
-                    />
-                  </template>
-
-                  <VisibilityTooltipCard
-                    title="Datastream is currently"
-                    :items="[
-                      {
-                        label: 'Clicking this will',
-                        value: item.isPrivate
-                          ? 'Make this datastream and all its metadata and observations publicly visible.'
-                          : 'Hide this datastream from guests of your site along with all its metadata and observations.',
-                      },
-                    ]"
-                    :is-visible="!item.isPrivate"
-                  />
-                </v-tooltip>
-
-                <v-tooltip
-                  v-if="
-                    !hasPermission(
-                      PermissionResource.Datastream,
-                      PermissionAction.View,
-                      workspace
-                    ) && !item.isVisible
-                  "
-                  bottom
-                  :openDelay="100"
-                >
-                  <template v-slot:activator="{ props }">
-                    <v-icon
-                      v-bind="props"
-                      :icon="mdiLock"
-                      color="red-darken-2"
-                    />
-                  </template>
-                  <span>The data for this datastream is private </span>
-                </v-tooltip>
-
-                <v-menu v-else>
-                  <template v-slot:activator="{ props }">
-                    <v-icon
-                      v-bind="props"
-                      :icon="mdiDotsVertical"
-                      :data-testid="`datastream-actions-${item.id}`"
-                    />
-                  </template>
-                  <v-list>
-                    <v-list-item
-                      v-if="
-                        hasPermission(
-                          PermissionResource.Datastream,
-                          PermissionAction.Edit,
-                          workspace
-                        )
-                      "
-                      :prepend-icon="mdiPencil"
-                      title="Edit datastream metadata"
-                      :data-testid="`edit-datastream-${item.id}`"
-                      @click="openDialog(item, 'edit')"
-                    />
-                    <div
-                      v-if="
-                        hasPermission(
-                          PermissionResource.Datastream,
-                          PermissionAction.Delete,
-                          workspace
-                        )
-                      "
-                    >
-                      <v-list-item
-                        :prepend-icon="mdiDelete"
-                        title="Delete datastream"
-                        :data-testid="`delete-datastream-${item.id}`"
-                        @click="openDialog(item, 'delete')"
-                      />
-                    </div>
-                    <v-list-item
-                      v-if="
-                        hasPermission(
-                          PermissionResource.Observation,
-                          PermissionAction.Delete,
-                          workspace
-                        )
-                      "
-                      :prepend-icon="mdiDeleteOutline"
-                      title="Delete data from datastream"
-                      :data-testid="`delete-datastream-data-${item.id}`"
-                      @click="openObservationDialog(item)"
-                    />
-                    <v-list-item
-                      :prepend-icon="mdiChartLine"
-                      title="Visualize data"
-                      :data-testid="`visualize-datastream-${item.id}`"
-                      :to="{
-                        name: 'VisualizeData',
-                        query: { sites: item.thingId, datastreams: item.id },
-                      }"
-                    />
-                    <v-list-item
-                      :prepend-icon="mdiDownload"
-                      title="Download data"
-                      :data-testid="`download-datastream-${item.id}`"
-                      @click="onDownload(item.id)"
-                    />
-                  </v-list>
-                </v-menu>
-              </div>
-              <v-btn
-                variant="outlined"
-                class="mt-2 datastream-meta-btn"
-                :data-testid="`datastream-metadata-${item.id}`"
-                @click="openInfoCardFor(item)"
-              >
-                View Full Metadata
-              </v-btn>
-              <div v-if="downloading[item.id]" class="datastream-download mt-2">
-                <v-progress-circular
-                  indeterminate
-                  size="16"
-                  width="2"
-                  color="primary"
-                />
-                preparing file...
-              </div>
-            </div>
-          </td>
-        </tr>
-        <tr
-          v-if="canViewOrchestrationInfo && linkedTasksLoaded"
-          class="datastream-task-row"
-        >
-          <td :colspan="headers.length" class="datastream-task-row__cell">
-            <div
-              class="datastream-task-link datastream-task-link--table"
-              :class="datastreamTaskLinkClass(item.id)"
-            >
-              <v-icon
-                :class="[
-                  'datastream-task-link__icon',
-                  linkedTasksForDatastream(item.id).length === 1
-                    ? linkedTasksForDatastream(item.id)[0].iconClass
-                    : '',
-                ]"
-                :icon="
-                  !linkedTasksForDatastream(item.id).length
-                    ? mdiLinkOff
-                    : linkedTasksForDatastream(item.id).length > 1
-                    ? mdiAlertOctagon
-                    : linkedTasksForDatastream(item.id)[0].icon
+            <div class="mt-1">
+              <div
+                v-if="
+                  !hasPermission(
+                    PermissionResource.Datastream,
+                    PermissionAction.View,
+                    workspace
+                  ) && !item.isVisible
                 "
-                size="20"
-              />
-              <div class="datastream-task-link__body">
-                <div class="datastream-task-link__meta">
-                  <span class="datastream-task-link__label">
-                    {{
-                      linkedTasksForDatastream(item.id).length > 1
-                        ? 'Multiple task targets'
-                        : linkedTasksForDatastream(item.id).length === 1
-                        ? linkedTasksForDatastream(item.id)[0].label
-                        : 'No task connected'
-                    }}
-                  </span>
-                  <template
-                    v-if="linkedTasksForDatastream(item.id).length === 1"
+                class="text-body-2"
+              >
+                Data is private for this datastream
+              </div>
+              <div v-else>
+                <Sparkline
+                  class="mt-1"
+                  :datastream="item"
+                  @openChart="openCharts[item.id] = true"
+                  @latest-value="
+                    (value) => handleLatestValueUpdate(item.id, value)
+                  "
+                  :unitName="item.unitName"
+                />
+                <div
+                  v-if="Number(item.valueCount) > 0"
+                  class="mt-1 text-base leading-[1.3]"
+                  :class="latestStatusClass(item)"
+                >
+                  <strong class="mr-2 font-semibold"
+                    >Latest observation:</strong
                   >
-                    <RouterLink
-                      class="datastream-task-link__name"
-                      :to="linkedTasksForDatastream(item.id)[0].route"
-                    >
-                      {{ linkedTasksForDatastream(item.id)[0].name }}
-                    </RouterLink>
-                    <TaskStatus
-                      :status="linkedTasksForDatastream(item.id)[0].status"
-                      :paused="linkedTasksForDatastream(item.id)[0].paused"
-                    />
-                  </template>
-                  <span v-else class="datastream-task-link__conflict-text">
-                    {{
-                      linkedTasksForDatastream(item.id).length > 1
-                        ? `${
-                            linkedTasksForDatastream(item.id).length
-                          } tasks are feeding this datastream.`
-                        : 'No task is feeding this datastream.'
-                    }}
-                  </span>
+                  <span class="font-semibold">{{ item.endDate }}</span>
                 </div>
                 <div
-                  v-if="linkedTasksForDatastream(item.id).length > 1"
-                  class="datastream-task-link__tasks"
+                  v-if="shouldShowLatestValue(item.id)"
+                  class="mt-1 text-base leading-[1.3]"
+                  :class="latestStatusClass(item)"
                 >
-                  <RouterLink
-                    v-for="task in linkedTasksForDatastream(item.id)"
-                    :key="task.id"
-                    :to="task.route"
-                  >
-                    {{ task.name }}
-                  </RouterLink>
+                  <strong class="mr-2 font-semibold">Latest value:</strong>
+                  <span class="font-semibold">{{
+                    latestValueDisplay(item)
+                  }}</span>
                 </div>
               </div>
-              <v-btn
-                v-if="linkedTasksForDatastream(item.id).length === 1"
-                size="small"
-                variant="text"
-                color="primary"
-                :append-icon="mdiChevronRight"
-                :to="linkedTasksForDatastream(item.id)[0].route"
-              >
-                Manage
-              </v-btn>
             </div>
-          </td>
-        </tr>
-      </template>
-    </v-data-table-virtual>
+
+            <v-dialog v-model="openCharts[item.id]" width="80rem">
+              <DatastreamPopupPlot
+                :datastream="item"
+                @close="openCharts[item.id] = false"
+              />
+            </v-dialog>
+          </div>
+          <div class="datastream-info-list">
+            <p class="datastream-line">
+              <strong class="mr-2">Identifier:</strong>
+              <span class="datastream-id">
+                {{ item.id }}
+                <v-tooltip text="Copy ID">
+                  <template #activator="{ props }">
+                    <v-btn
+                      v-bind="props"
+                      icon
+                      size="small"
+                      variant="text"
+                      @click.stop="copyDatastreamId(item.id)"
+                    >
+                      <v-icon :icon="mdiContentCopy" size="small" />
+                    </v-btn>
+                  </template>
+                </v-tooltip>
+              </span>
+            </p>
+            <p class="datastream-line">
+              <strong class="mr-2">Sampled medium:</strong>
+              <span>{{ item.sampledMedium }}</span>
+            </p>
+            <p class="datastream-line">
+              <strong class="mr-2">Method:</strong>
+              <span>{{ item.sensorName }}</span>
+            </p>
+            <p class="datastream-line">
+              <strong class="mr-2">No data value:</strong>
+              <span>{{ item.noDataValue }}</span>
+            </p>
+            <p class="datastream-line">
+              <strong class="mr-2">Begin date:</strong>
+              <span>{{ item.beginDate }}</span>
+            </p>
+            <p class="datastream-line">
+              <strong class="mr-2">End date:</strong>
+              <span>{{ item.endDate }}</span>
+            </p>
+            <p class="datastream-line">
+              <strong class="mr-2">Number of observations:</strong>
+              <span>{{ item.valueCount }}</span>
+            </p>
+          </div>
+          <div class="datastream-actions">
+            <div class="datastream-actions__icons">
+              <v-tooltip
+                bottom
+                :openDelay="500"
+                content-class="pa-0 ma-0 bg-transparent"
+                v-if="
+                  hasPermission(
+                    PermissionResource.Datastream,
+                    PermissionAction.Edit,
+                    workspace
+                  )
+                "
+              >
+                <template #activator="{ props: tp }">
+                  <v-icon
+                    v-bind="tp"
+                    :icon="item.isVisible ? mdiFileEyeOutline : mdiFileRemove"
+                    :color="item.isVisible ? 'green' : 'red-darken-2'"
+                    :data-testid="`data-visibility-toggle-${item.id}`"
+                    small
+                    @click="toggleDataVisibility(item)"
+                  />
+                </template>
+
+                <VisibilityTooltipCard
+                  title="Observations are currently"
+                  :items="[
+                    {
+                      label: 'Clicking this will',
+                      value: item.isVisible
+                        ? 'Hide data for this datastream from guests of your site while keeping the datastream metadata publicly visible.'
+                        : 'Make the observations and metadata for this datastream visible to guests of your site.',
+                    },
+                  ]"
+                  :is-visible="item.isVisible"
+                />
+              </v-tooltip>
+
+              <v-tooltip
+                bottom
+                :openDelay="500"
+                v-if="
+                  hasPermission(
+                    PermissionResource.Datastream,
+                    PermissionAction.Edit,
+                    workspace
+                  )
+                "
+                content-class="pa-0 ma-0 bg-transparent"
+              >
+                <template v-slot:activator="{ props }">
+                  <v-icon
+                    :icon="item.isPrivate ? mdiLock : mdiLockOpenVariant"
+                    :color="item.isPrivate ? 'red-darken-2' : 'green'"
+                    :data-testid="`datastream-privacy-toggle-${item.id}`"
+                    small
+                    v-bind="props"
+                    @click="toggleVisibility(item)"
+                  />
+                </template>
+
+                <VisibilityTooltipCard
+                  title="Datastream is currently"
+                  :items="[
+                    {
+                      label: 'Clicking this will',
+                      value: item.isPrivate
+                        ? 'Make this datastream and all its metadata and observations publicly visible.'
+                        : 'Hide this datastream from guests of your site along with all its metadata and observations.',
+                    },
+                  ]"
+                  :is-visible="!item.isPrivate"
+                />
+              </v-tooltip>
+
+              <v-tooltip
+                v-if="
+                  !hasPermission(
+                    PermissionResource.Datastream,
+                    PermissionAction.View,
+                    workspace
+                  ) && !item.isVisible
+                "
+                bottom
+                :openDelay="100"
+              >
+                <template v-slot:activator="{ props }">
+                  <v-icon v-bind="props" :icon="mdiLock" color="red-darken-2" />
+                </template>
+                <span>The data for this datastream is private </span>
+              </v-tooltip>
+
+              <v-menu v-else>
+                <template v-slot:activator="{ props }">
+                  <v-icon
+                    v-bind="props"
+                    :icon="mdiDotsVertical"
+                    :data-testid="`datastream-actions-${item.id}`"
+                  />
+                </template>
+                <v-list>
+                  <v-list-item
+                    v-if="
+                      hasPermission(
+                        PermissionResource.Datastream,
+                        PermissionAction.Edit,
+                        workspace
+                      )
+                    "
+                    :prepend-icon="mdiPencil"
+                    title="Edit datastream metadata"
+                    :data-testid="`edit-datastream-${item.id}`"
+                    @click="openDialog(item, 'edit')"
+                  />
+                  <div
+                    v-if="
+                      hasPermission(
+                        PermissionResource.Datastream,
+                        PermissionAction.Delete,
+                        workspace
+                      )
+                    "
+                  >
+                    <v-list-item
+                      :prepend-icon="mdiDelete"
+                      title="Delete datastream"
+                      :data-testid="`delete-datastream-${item.id}`"
+                      @click="openDialog(item, 'delete')"
+                    />
+                  </div>
+                  <v-list-item
+                    v-if="
+                      hasPermission(
+                        PermissionResource.Observation,
+                        PermissionAction.Delete,
+                        workspace
+                      )
+                    "
+                    :prepend-icon="mdiDeleteOutline"
+                    title="Delete data from datastream"
+                    :data-testid="`delete-datastream-data-${item.id}`"
+                    @click="openObservationDialog(item)"
+                  />
+                  <v-list-item
+                    :prepend-icon="mdiChartLine"
+                    title="Visualize data"
+                    :data-testid="`visualize-datastream-${item.id}`"
+                    :to="{
+                      name: 'VisualizeData',
+                      query: { sites: item.thingId, datastreams: item.id },
+                    }"
+                  />
+                  <v-list-item
+                    :prepend-icon="mdiDownload"
+                    title="Download data"
+                    :data-testid="`download-datastream-${item.id}`"
+                    @click="onDownload(item.id)"
+                  />
+                </v-list>
+              </v-menu>
+            </div>
+            <v-btn
+              variant="outlined"
+              class="mt-2 datastream-meta-btn"
+              :data-testid="`datastream-metadata-${item.id}`"
+              @click="openInfoCardFor(item)"
+            >
+              View Full Metadata
+            </v-btn>
+            <div v-if="downloading[item.id]" class="datastream-download mt-2">
+              <v-progress-circular
+                indeterminate
+                size="16"
+                width="2"
+                color="primary"
+              />
+              preparing file...
+            </div>
+          </div>
+        </div>
+
+        <div
+          v-if="showTaskRow"
+          class="datastream-task-link datastream-task-link--card"
+          :class="datastreamTaskLinkClass(item.id)"
+        >
+          <v-icon
+            :class="[
+              'datastream-task-link__icon',
+              linkedTasksForDatastream(item.id).length === 1
+                ? linkedTasksForDatastream(item.id)[0].iconClass
+                : '',
+            ]"
+            :icon="
+              !linkedTasksForDatastream(item.id).length
+                ? mdiLinkOff
+                : linkedTasksForDatastream(item.id).length > 1
+                ? mdiAlertOctagon
+                : linkedTasksForDatastream(item.id)[0].icon
+            "
+            size="20"
+          />
+          <div class="datastream-task-link__body">
+            <div class="datastream-task-link__meta">
+              <span class="datastream-task-link__label">
+                {{
+                  linkedTasksForDatastream(item.id).length > 1
+                    ? 'Multiple task targets'
+                    : linkedTasksForDatastream(item.id).length === 1
+                    ? linkedTasksForDatastream(item.id)[0].label
+                    : 'No task connected'
+                }}
+              </span>
+              <template v-if="linkedTasksForDatastream(item.id).length === 1">
+                <RouterLink
+                  class="datastream-task-link__name"
+                  :to="linkedTasksForDatastream(item.id)[0].route"
+                >
+                  {{ linkedTasksForDatastream(item.id)[0].displayName }}
+                </RouterLink>
+                <span
+                  class="datastream-task-link__status"
+                  :title="
+                    displayedTaskStatus(linkedTasksForDatastream(item.id)[0])
+                  "
+                >
+                  <span
+                    class="datastream-task-link__dot"
+                    :style="{
+                      backgroundColor: taskStatusColor(
+                        linkedTasksForDatastream(item.id)[0]
+                      ),
+                    }"
+                  />
+                  <span class="datastream-task-link__last-ran">
+                    {{ lastRanLabel(linkedTasksForDatastream(item.id)[0]) }}
+                  </span>
+                </span>
+              </template>
+              <span v-else class="datastream-task-link__conflict-text">
+                {{
+                  linkedTasksForDatastream(item.id).length > 1
+                    ? `${
+                        linkedTasksForDatastream(item.id).length
+                      } tasks are feeding this datastream.`
+                    : ''
+                }}
+              </span>
+            </div>
+            <div
+              v-if="linkedTasksForDatastream(item.id).length > 1"
+              class="datastream-task-link__tasks"
+            >
+              <RouterLink
+                v-for="task in linkedTasksForDatastream(item.id)"
+                :key="task.id"
+                :to="task.route"
+              >
+                {{ task.displayName }}
+              </RouterLink>
+            </div>
+          </div>
+          <v-btn
+            v-if="linkedTasksForDatastream(item.id).length === 1"
+            size="small"
+            variant="text"
+            color="primary"
+            :append-icon="mdiChevronRight"
+            :to="linkedTasksForDatastream(item.id)[0].route"
+          >
+            Manage
+          </v-btn>
+        </div>
+      </div>
+    </div>
   </v-card>
 
   <v-dialog v-model="openCreate" width="80rem">
@@ -858,11 +876,19 @@ import DatastreamPopupPlot from '@/components/Datastream/DatastreamPopupPlot.vue
 import DatastreamForm from '@/components/Datastream/DatastreamForm.vue'
 import DatastreamDeleteCard from './DatastreamDeleteCard.vue'
 import Sparkline from '@/components/Sparkline.vue'
-import TaskStatus from '@/components/Orchestration/shared/TaskStatus.vue'
-import { computed, reactive, ref, toRef, watch } from 'vue'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  reactive,
+  ref,
+  toRef,
+  watch,
+} from 'vue'
 import { useMetadata } from '@/composables/useMetadata'
 import { storeToRefs } from 'pinia'
 import { useThingStore } from '@/store/thing'
+import { useWorkspaceStore } from '@/store/workspaces'
 import { Datastream, Workspace, type StatusType } from '@hydroserver/client'
 import { useWorkspacePermissions } from '@/composables/useWorkspacePermissions'
 import { useTableLogic } from '@/composables/useTableLogic'
@@ -900,16 +926,20 @@ import {
 
 const props = defineProps({
   workspace: { type: Object as () => Workspace, required: true },
+  targetDatastreamId: { type: String, default: '' },
 })
 
 type LinkedDatastreamTask = {
   id: string
   name: string
+  dataConnectionName: string | null
+  displayName: string
   label: string
   icon: string
   iconClass: string
   status: StatusType
   paused: boolean
+  lastRunAt: string | null
   route: {
     name: string
     params: { view: string }
@@ -923,6 +953,12 @@ const workspaceRef = toRef(props, 'workspace')
 const thingIdRef = computed(() => thing.value!.id)
 const downloading = reactive<Record<string, boolean>>({})
 const search = ref()
+const datastreamSectionRef = ref<any>(null)
+const datastreamTableRef = ref<{
+  scrollToIndex?: (index: number) => void
+} | null>(null)
+const highlightedDatastreamId = ref('')
+let highlightTimeout: number | undefined
 const { smAndDown } = useDisplay()
 const isMobile = computed(() => smAndDown.value)
 
@@ -939,21 +975,12 @@ const openInfoCardFor = (datastream: Datastream) => {
   openInfoCard.value = true
 }
 
-const { hasPermission, isAdmin, isOwner } =
-  useWorkspacePermissions(workspaceRef)
+const { hasPermission } = useWorkspacePermissions(workspaceRef)
+const { workspaces } = storeToRefs(useWorkspaceStore())
 
 const canViewOrchestrationInfo = computed(() => {
-  const workspace = props.workspace
-  const roleName = `${workspace.collaboratorRole?.name ?? ''}`.toLowerCase()
-  return (
-    isAdmin() ||
-    isOwner(workspace) ||
-    roleName === 'editor' ||
-    hasPermission(
-      PermissionResource.Workspace,
-      PermissionAction.Edit,
-      workspace
-    )
+  return workspaces.value.some(
+    (workspace) => workspace.id === props.workspace.id
   )
 })
 
@@ -1081,14 +1108,7 @@ const normalizedSearch = computed(() =>
   (search.value ?? '').toString().trim().toLowerCase()
 )
 
-const isDatastreamStale = (datastream: Datastream) => {
-  if (!datastream.phenomenonEndTime) return true
-  const endTime = new Date(datastream.phenomenonEndTime)
-  const seventyTwoHoursAgo = new Date(Date.now() - 72 * 60 * 60 * 1000)
-  return endTime < seventyTwoHoursAgo
-}
-
-const mobileDatastreams = computed(() => {
+const tableDatastreams = computed(() => {
   const sorted = [...visibleDatastreams.value].sort((a, b) =>
     (a.name || a.OPName || '').localeCompare(b.name || b.OPName || '')
   )
@@ -1099,8 +1119,99 @@ const mobileDatastreams = computed(() => {
   )
 })
 
+const deepLinkedDatastreamId = computed(() => props.targetDatastreamId.trim())
+
+const targetDatastreamIndex = computed(() => {
+  if (!deepLinkedDatastreamId.value) return -1
+  return tableDatastreams.value.findIndex(
+    (datastream) => String(datastream.id) === deepLinkedDatastreamId.value
+  )
+})
+
+function isTargetDatastream(datastreamId: string) {
+  return (
+    !!highlightedDatastreamId.value &&
+    String(datastreamId) === highlightedDatastreamId.value
+  )
+}
+
+function findTargetDatastreamElement() {
+  if (!deepLinkedDatastreamId.value) return null
+  const section = datastreamSectionElement()
+  const elements = Array.from(
+    section?.querySelectorAll<HTMLElement>('[data-datastream-id]') ?? []
+  )
+  return (
+    elements.find(
+      (element) => element.dataset.datastreamId === deepLinkedDatastreamId.value
+    ) ?? null
+  )
+}
+
+function datastreamSectionElement(): HTMLElement | null {
+  const section = datastreamSectionRef.value
+  if (!section) return null
+  if (section instanceof HTMLElement) return section
+  return section.$el instanceof HTMLElement ? section.$el : null
+}
+
+function highlightTargetDatastream() {
+  highlightedDatastreamId.value = deepLinkedDatastreamId.value
+  if (highlightTimeout) window.clearTimeout(highlightTimeout)
+  highlightTimeout = window.setTimeout(() => {
+    highlightedDatastreamId.value = ''
+  }, 5000)
+}
+
+async function scrollToTargetDatastream() {
+  if (!deepLinkedDatastreamId.value) return
+  const canAccessDatastream = visibleDatastreams.value.some(
+    (datastream) => String(datastream.id) === deepLinkedDatastreamId.value
+  )
+  if (!canAccessDatastream) return
+
+  if (targetDatastreamIndex.value === -1 && normalizedSearch.value) {
+    search.value = ''
+    await nextTick()
+  }
+
+  await nextTick()
+  datastreamSectionElement()?.scrollIntoView({
+    block: 'start',
+    behavior: 'smooth',
+  })
+
+  if (!isMobile.value && targetDatastreamIndex.value >= 0) {
+    datastreamTableRef.value?.scrollToIndex?.(targetDatastreamIndex.value)
+    await nextTick()
+  }
+
+  window.setTimeout(() => {
+    findTargetDatastreamElement()?.scrollIntoView({
+      block: 'center',
+      behavior: 'smooth',
+    })
+    highlightTargetDatastream()
+  }, 80)
+}
+
+const isDatastreamStale = (datastream: Datastream) => {
+  if (!datastream.phenomenonEndTime) return true
+  const endTime = new Date(datastream.phenomenonEndTime)
+  const seventyTwoHoursAgo = new Date(Date.now() - 72 * 60 * 60 * 1000)
+  return endTime < seventyTwoHoursAgo
+}
+
+const mobileDatastreams = computed(() => {
+  return tableDatastreams.value
+})
+
 const linkedTasksForDatastream = (datastreamId: string) =>
   linkedTasksByDatastreamId.value[datastreamId] ?? []
+
+const showTaskRow = computed(
+  () => canViewOrchestrationInfo.value && linkedTasksLoaded.value
+)
 
 const datastreamTaskLinkClass = (datastreamId: string) => {
   const linkedTasks = linkedTasksForDatastream(datastreamId)
@@ -1117,6 +1228,54 @@ const datastreamTaskLinkClass = (datastreamId: string) => {
     'Loading paused': 'datastream-task-link--none',
   }
   return statusClass[linkedTasks[0].status]
+}
+
+const TASK_STATUS_DOT_COLORS: Record<StatusType, string> = {
+  OK: '#357a38',
+  Pending: '#1769aa',
+  'Needs attention': '#c62828',
+  'Behind schedule': '#e65100',
+  Unknown: '#546e7a',
+  'Loading paused': '#546e7a',
+}
+
+const displayedTaskStatus = (task: LinkedDatastreamTask): StatusType =>
+  task.paused && task.status !== 'Needs attention'
+    ? 'Loading paused'
+    : task.status
+
+const taskStatusColor = (task: LinkedDatastreamTask) =>
+  TASK_STATUS_DOT_COLORS[displayedTaskStatus(task)] ??
+  TASK_STATUS_DOT_COLORS.Unknown
+
+const formatRelativeTime = (iso: string | null) => {
+  if (!iso) return null
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return null
+
+  const diffSeconds = Math.round((Date.now() - then) / 1000)
+  if (diffSeconds < 45) return 'just now'
+
+  const units: [number, string][] = [
+    [60, 'min'],
+    [60, 'hr'],
+    [24, 'day'],
+    [30, 'mo'],
+    [12, 'yr'],
+  ]
+  let value = diffSeconds / 60
+  let label = 'min'
+  for (let i = 1; i < units.length && value >= units[i][0]; i += 1) {
+    value /= units[i][0]
+    label = units[i][1]
+  }
+  const rounded = Math.round(value)
+  return `${rounded} ${label}${rounded === 1 ? '' : 's'} ago`
+}
+
+const lastRanLabel = (task: LinkedDatastreamTask) => {
+  const relative = formatRelativeTime(task.lastRunAt)
+  return relative ? `Last ran ${relative}` : 'Never ran'
 }
 
 const routeForIngestionTask = (task: any) => {
@@ -1174,6 +1333,21 @@ const targetDatastreamId = (mapping: any) =>
 const taskPaused = (task: any) =>
   task.schedule ? task.schedule.enabled === false : false
 
+const truncateTaskInfoPart = (value: unknown, maxLength = 250) => {
+  const text = `${value ?? ''}`.trim()
+  return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text
+}
+
+const dataConnectionNameForTask = (task: any) =>
+  task.dataConnection?.name ?? task.dataConnectionName ?? null
+
+const linkedTaskDisplayName = (task: any) => {
+  const taskName = truncateTaskInfoPart(task.name || task.id)
+  const dataConnectionName = dataConnectionNameForTask(task)
+  if (!dataConnectionName) return taskName
+  return `${truncateTaskInfoPart(dataConnectionName)} · ${taskName}`
+}
+
 const addLinkedTask = (
   grouped: Record<string, LinkedDatastreamTask[]>,
   seen: Set<string>,
@@ -1189,11 +1363,14 @@ const addLinkedTask = (
   grouped[datastreamId].push({
     id: String(task.id),
     name: task.name,
+    dataConnectionName: dataConnectionNameForTask(task),
+    displayName: linkedTaskDisplayName(task),
     label: config.label,
     icon: config.icon,
     iconClass: config.iconClass ?? '',
     status: getTaskStatusText(task),
     paused: taskPaused(task),
+    lastRunAt: task.latestRun?.startedAt ?? task.latestRun?.finishedAt ?? null,
     route: config.route,
   })
 }
@@ -1306,6 +1483,22 @@ watch(
   { immediate: true }
 )
 
+watch(
+  [
+    deepLinkedDatastreamId,
+    () => tableDatastreams.value.map((datastream) => datastream.id).join(','),
+    isMobile,
+  ],
+  () => {
+    void scrollToTargetDatastream()
+  },
+  { immediate: true, flush: 'post' }
+)
+
+onBeforeUnmount(() => {
+  if (highlightTimeout) window.clearTimeout(highlightTimeout)
+})
+
 const onDownload = async (datastreamId: string) => {
   if (downloading[datastreamId]) return
   downloading[datastreamId] = true
@@ -1391,22 +1584,6 @@ async function onObservationsDelete() {
   openObservationsDelete.value = false
 }
 
-const sortBy = [{ key: 'name' }]
-const headers = [
-  {
-    title: 'Observation information',
-    key: 'latest',
-    sortable: false,
-  },
-  {
-    title: 'Datastream information',
-    key: 'info',
-    value: 'searchText',
-    sortable: false,
-  },
-  { title: 'Actions', key: 'actions', sortable: false },
-]
-
 const loadDatastreams = async () => {
   try {
     items.value = await hs.datastreams.listAllItems({
@@ -1419,11 +1596,61 @@ const loadDatastreams = async () => {
 </script>
 
 <style scoped>
-.datastream-table :deep(.v-data-table__td) {
-  vertical-align: top;
-  white-space: normal;
-  padding-top: 0.4rem !important;
-  padding-bottom: 0.4rem !important;
+/* Datastream list — plain card list (replaces the Vuetify data table for full
+   layout control), modelled on the Claude Design "strip" prototype. */
+.datastream-list {
+  --datastream-list-grid: minmax(0, 1.1fr) minmax(0, 1.3fr) 10.75rem;
+  --datastream-list-inline: calc(0.75rem + 1px + 0.85rem);
+  padding: 0 0 0.75rem;
+  background: #fafbfc;
+  max-height: 100vh;
+  overflow-y: auto;
+}
+
+.datastream-list__head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: var(--datastream-list-grid);
+  gap: 1.25rem;
+  padding: 0.5rem var(--datastream-list-inline);
+  background: rgb(var(--v-theme-surface));
+  border-bottom: 1px solid #e2e5e9;
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-on-surface), 0.56);
+}
+
+.datastream-list__head-actions {
+  text-align: right;
+}
+
+.ds-card {
+  margin: 0.5rem 0.75rem 0;
+  background: #fff;
+  border: 1px solid #e2e5e9;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.ds-card--highlighted {
+  border-color: #1565c0;
+  box-shadow: 0 0 0 2px rgba(21, 101, 192, 0.18);
+}
+
+.ds-card__grid {
+  display: grid;
+  grid-template-columns: var(--datastream-list-grid);
+  gap: 1.25rem;
+  padding: 0.6rem 0.85rem;
+}
+
+.ds-card__grid > .datastream-actions {
+  align-items: flex-end;
 }
 
 .datastream-toolbar {
@@ -1523,6 +1750,11 @@ const loadDatastreams = async () => {
   gap: 0.5rem;
 }
 
+.datastream-card--highlighted {
+  border-color: #1565c0;
+  box-shadow: 0 0 0 2px rgba(21, 101, 192, 0.18);
+}
+
 .datastream-card__content {
   display: flex;
   flex-direction: column;
@@ -1602,64 +1834,62 @@ const loadDatastreams = async () => {
 .datastream-task-link {
   display: flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.75rem;
   width: 100%;
   margin-top: 0.75rem;
   padding: 0.55rem 0.65rem;
-  border-left: 4px solid #757575;
+  border-left: 3px solid #546e7a;
   border-radius: 6px;
-  background: #f5f5f5;
-  color: #424242;
+  background: #eceff1;
+  color: rgba(0, 0, 0, 0.87);
 }
 
-.datastream-task-row__cell {
-  padding: 0 !important;
-  border-top: 0 !important;
-}
-
-.datastream-task-link--table {
+/* Task strip sits flush at the bottom of each card as an integral footer. */
+.datastream-task-link--card {
   margin-top: 0;
   border-radius: 0;
+  width: 100%;
+  padding: 0.45rem 0.85rem;
+  border-top: 1px solid #eef0f3;
 }
 
 .datastream-task-link--ok {
-  border-left-color: #2e7d32;
-  background: #f1f8f3;
-  color: #1f1d24;
+  border-left-color: #357a38;
+  background: #e8f5e9;
+  color: rgba(0, 0, 0, 0.87);
 }
 
 .datastream-task-link--attention,
 .datastream-task-link--conflict {
   border-left-color: #c62828;
-  background: #fff7f7;
-  color: #1f1d24;
-  box-shadow: inset 0 0 0 1px rgba(198, 40, 40, 0.1);
+  background: #fdecea;
+  color: rgba(0, 0, 0, 0.87);
 }
 
 .datastream-task-link--pending {
-  border-left-color: #1976d2;
-  background: #eef6ff;
-  color: #1f1d24;
+  border-left-color: #1769aa;
+  background: #e3f1fd;
+  color: rgba(0, 0, 0, 0.87);
 }
 
 .datastream-task-link--behind {
   border-left-color: #e65100;
-  background: #fff4e5;
-  color: #1f1d24;
+  background: #fff3e0;
+  color: rgba(0, 0, 0, 0.87);
 }
 
 .datastream-task-link--none {
-  border-left-color: #757575;
-  background: #f5f5f5;
-  color: #424242;
+  border-left-color: #546e7a;
+  background: #eceff1;
+  color: rgba(0, 0, 0, 0.87);
 }
 
 .datastream-task-link__icon--source {
-  color: #1976d2 !important;
+  color: #2196f3 !important;
 }
 
 .datastream-task-link__icon--derived {
-  color: #8e24aa !important;
+  color: #6a1b9a !important;
 }
 
 .datastream-task-link__icon--aggregation {
@@ -1686,23 +1916,47 @@ const loadDatastreams = async () => {
 }
 
 .datastream-task-link__label {
-  font-size: 0.72rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.625rem;
   font-weight: 700;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.07em;
   text-transform: uppercase;
-  color: currentColor;
-  opacity: 0.72;
+  color: rgba(0, 0, 0, 0.42);
 }
 
 .datastream-task-link__name {
-  color: inherit;
-  font-weight: 700;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 0.8rem;
+  font-weight: 600;
   text-decoration: none;
 }
 
 .datastream-task-link__name:hover,
 .datastream-task-link__tasks a:hover {
   text-decoration: underline;
+}
+
+.datastream-task-link__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.datastream-task-link__dot {
+  display: inline-block;
+  width: 0.44rem;
+  height: 0.44rem;
+  border-radius: 50%;
+  flex: none;
+}
+
+.datastream-task-link__last-ran {
+  font-size: 0.7rem;
+  font-weight: 500;
+  white-space: nowrap;
+  color: rgba(0, 0, 0, 0.42);
 }
 
 .datastream-task-link__conflict-text {
@@ -1747,22 +2001,6 @@ const loadDatastreams = async () => {
   .datastream-toolbar__actions :deep(.v-btn) {
     width: 100%;
     justify-content: center;
-  }
-
-  :deep(tbody .v-data-table__tr) {
-    display: block;
-    padding: 0.5rem 0;
-  }
-
-  :deep(tbody .v-data-table__td) {
-    display: block;
-    width: 100%;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-  }
-
-  :deep(tbody .v-data-table__td + .v-data-table__td) {
-    border-top: 1px solid rgba(0, 0, 0, 0.08);
   }
 
   .datastream-info-list,

--- a/apps/data-management/src/components/Orchestration/data-products/ProductTaskSwimlanes.vue
+++ b/apps/data-management/src/components/Orchestration/data-products/ProductTaskSwimlanes.vue
@@ -1,0 +1,353 @@
+<template>
+  <div class="swimlanes-view">
+    <div v-if="mappingRows.length" class="product-mappings">
+      <div class="product-mappings-head">Source datastream</div>
+      <div class="product-mappings-head product-mappings-head-target">
+        Target datastream
+      </div>
+
+      <div
+        v-for="row in mappingRows"
+        :key="row.key"
+        class="product-mapping-row"
+      >
+        <div class="product-mapping-source">
+          <div class="etl-source-display datastream-display">
+            <div class="datastream-display__content">
+              <span class="target-name">
+                {{
+                  datastreamName(row.sourceDatastream, row.sourceDatastreamId)
+                }}
+              </span>
+              <span v-if="row.sourceDetail" class="target-thing">
+                {{ row.sourceDetail }}
+              </span>
+              <span v-if="thingName(row.sourceDatastream)" class="target-thing">
+                {{ thingName(row.sourceDatastream) }}
+              </span>
+              <span class="target-id">{{ row.sourceDatastreamId || '—' }}</span>
+            </div>
+            <DatastreamSiteButton
+              :datastream="row.sourceDatastream"
+              :datastream-id="row.sourceDatastreamId"
+              :fallback-thing-id="
+                thingId(row.sourceDatastream) || props.thingId
+              "
+            />
+          </div>
+        </div>
+
+        <div class="product-mapping-arrow">
+          <v-icon :icon="mdiArrowRight" size="22" />
+        </div>
+
+        <div class="product-mapping-target">
+          <div class="etl-target-display datastream-display">
+            <div class="datastream-display__content">
+              <span class="target-name">
+                {{
+                  datastreamName(row.targetDatastream, row.targetDatastreamId)
+                }}
+              </span>
+              <span v-if="thingName(row.targetDatastream)" class="target-thing">
+                {{ thingName(row.targetDatastream) }}
+              </span>
+              <span class="target-id">{{ row.targetDatastreamId || '—' }}</span>
+            </div>
+            <DatastreamSiteButton
+              :datastream="row.targetDatastream"
+              :datastream-id="row.targetDatastreamId"
+              :fallback-thing-id="
+                thingId(row.targetDatastream) || props.thingId
+              "
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-else class="empty-mappings">No mappings configured.</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { mdiArrowRight } from '@mdi/js'
+import DatastreamSiteButton from '@/components/Orchestration/shared/DatastreamSiteButton.vue'
+import { useOrchestrationStore } from '@/store/orchestration'
+import { datastreamThingId } from '@/utils/orchestration/datastreams'
+
+type ProductTaskLabel = 'aggregation' | 'expression' | 'derivation'
+type DatastreamLike = {
+  id?: string
+  name?: string
+  thingId?: string
+  thing_id?: string
+  thing?: { id?: string }
+} | null
+
+type MappingRow = {
+  key: string
+  sourceDatastream: DatastreamLike
+  sourceDatastreamId: string
+  sourceDetail: string
+  targetDatastream: DatastreamLike
+  targetDatastreamId: string
+}
+
+const props = defineProps<{
+  task: any
+  taskLabel: ProductTaskLabel
+  thingId?: string | null
+}>()
+
+const {
+  linkedDatastreams,
+  workspaceDatastreams,
+  draftDatastreams,
+  workspaceThings,
+} = storeToRefs(useOrchestrationStore())
+
+const allKnownDatastreams = computed(() => [
+  ...workspaceDatastreams.value,
+  ...linkedDatastreams.value,
+  ...draftDatastreams.value,
+])
+
+const mappingRows = computed<MappingRow[]>(() => {
+  if (props.taskLabel === 'derivation') {
+    return (props.task?.compositeExpressionTransformations ?? []).flatMap(
+      (transformation: any, transformationIndex: number) => {
+        const targetDatastream = resolveDatastream(
+          transformation.outputDatastream,
+          transformation.outputDatastreamId
+        )
+        const targetDatastreamId = datastreamId(
+          targetDatastream,
+          transformation.outputDatastreamId
+        )
+
+        return (transformation.inputDatastreams ?? []).map(
+          (input: any, inputIndex: number) => {
+            const sourceDatastream = resolveDatastream(
+              input.datastream ?? input.inputDatastream,
+              input.datastreamId ?? input.inputDatastreamId
+            )
+
+            return {
+              key: `${transformation.id ?? transformationIndex}-${
+                input.datastreamId ?? inputIndex
+              }`,
+              sourceDatastream,
+              sourceDatastreamId: datastreamId(
+                sourceDatastream,
+                input.datastreamId ?? input.inputDatastreamId
+              ),
+              sourceDetail: input.variableName
+                ? `Variable ${input.variableName}`
+                : '',
+              targetDatastream,
+              targetDatastreamId,
+            }
+          }
+        )
+      }
+    )
+  }
+
+  const transformations =
+    props.taskLabel === 'aggregation'
+      ? props.task?.aggregationTransformations ?? []
+      : props.task?.expressionTransformations ?? []
+
+  return transformations.map((transformation: any, index: number) => {
+    const sourceDatastream = resolveDatastream(
+      transformation.inputDatastream,
+      transformation.inputDatastreamId
+    )
+    const targetDatastream = resolveDatastream(
+      transformation.outputDatastream,
+      transformation.outputDatastreamId
+    )
+
+    return {
+      key: `${transformation.id ?? index}`,
+      sourceDatastream,
+      sourceDatastreamId: datastreamId(
+        sourceDatastream,
+        transformation.inputDatastreamId
+      ),
+      sourceDetail: '',
+      targetDatastream,
+      targetDatastreamId: datastreamId(
+        targetDatastream,
+        transformation.outputDatastreamId
+      ),
+    }
+  })
+})
+
+function resolveDatastream(datastream: DatastreamLike, id?: string | null) {
+  if (datastream?.id || datastream?.name) return datastream
+  if (!id) return null
+  const key = String(id)
+  return allKnownDatastreams.value.find((d) => String(d.id) === key) ?? null
+}
+
+function datastreamId(datastream: DatastreamLike, fallback?: string | null) {
+  return String(datastream?.id ?? fallback ?? '')
+}
+
+function datastreamName(datastream: DatastreamLike, fallbackId: string) {
+  if (datastream?.name) return datastream.name
+  if (!fallbackId) return '—'
+  return fallbackId
+}
+
+function thingId(datastream: DatastreamLike) {
+  return datastream ? datastreamThingId(datastream as any) : ''
+}
+
+function thingName(datastream: DatastreamLike) {
+  const id = thingId(datastream)
+  if (!id) return ''
+  return (
+    workspaceThings.value.find((thing) => thing.id === String(id))?.name || ''
+  )
+}
+</script>
+
+<style scoped>
+.swimlanes-view {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.product-mappings {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 42px minmax(0, 1fr);
+  gap: 5px 5px;
+  align-items: center;
+}
+.product-mappings-head {
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #4f4b59;
+  font-size: 0.68rem;
+  padding-bottom: 4px;
+}
+.product-mappings-head:first-child {
+  grid-column: 1 / 2;
+}
+.product-mappings-head-target {
+  grid-column: 3 / 4;
+}
+.product-mapping-row {
+  display: contents;
+}
+.product-mapping-source,
+.product-mapping-target {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+}
+.product-mapping-arrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #c0b8c9;
+  min-height: 40px;
+}
+.etl-source-display {
+  width: 100%;
+  min-height: 40px;
+  border: 1px solid #d0c9d8;
+  border-radius: 8px;
+  padding: 6px 12px;
+  background: #fdfdff;
+  font-size: 0.86rem;
+  color: #1c1b1f;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: left;
+  overflow: hidden;
+}
+.etl-target-display {
+  width: 100%;
+  min-height: 40px;
+  border: 1px solid #d0c9d8;
+  border-radius: 8px;
+  padding: 6px 12px;
+  background: #f6f9ff;
+  font-size: 0.86rem;
+  color: #1c1b1f;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: left;
+  overflow: hidden;
+}
+.datastream-display {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+.datastream-display__content {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.target-id {
+  color: rgba(0, 0, 0, 0.55);
+  overflow-wrap: anywhere;
+  white-space: normal;
+  font-size: 0.72rem;
+  margin-top: 2px;
+}
+.target-name {
+  font-weight: 600;
+  color: #1c1b1f;
+  font-size: 0.86rem;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+.target-thing {
+  color: rgba(0, 0, 0, 0.66);
+  overflow-wrap: anywhere;
+  white-space: normal;
+  font-size: 0.78rem;
+  margin-top: 2px;
+}
+.empty-mappings {
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.86rem;
+  padding: 10px 0;
+}
+
+@media (max-width: 960px) {
+  .product-mappings {
+    grid-template-columns: 1fr;
+  }
+  .product-mappings-head,
+  .product-mappings-head:first-child,
+  .product-mappings-head-target {
+    grid-column: 1 / -1;
+  }
+  .product-mapping-row {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 5px;
+  }
+  .product-mapping-arrow {
+    justify-content: flex-start;
+    min-height: 0;
+  }
+}
+</style>

--- a/apps/data-management/src/components/Orchestration/data-products/RatingCurveSwimlanes.vue
+++ b/apps/data-management/src/components/Orchestration/data-products/RatingCurveSwimlanes.vue
@@ -6,18 +6,23 @@
         Output datastream
       </div>
 
-      <div
-        v-for="(t, ti) in transformations"
-        :key="ti"
-        class="rc-mapping-row"
-      >
+      <div v-for="(t, ti) in transformations" :key="ti" class="rc-mapping-row">
         <div class="rc-mapping-source">
-          <div class="etl-source-display">
-            <span class="target-name">{{ t.inputDatastream?.name || '—' }}</span>
-            <span v-if="t.ratingCurve?.name" class="target-thing">
-              via {{ t.ratingCurve.name }}
-            </span>
-            <span class="target-id">{{ t.inputDatastream?.id || '—' }}</span>
+          <div class="etl-source-display datastream-display">
+            <div class="datastream-display__content">
+              <span class="target-name">{{
+                t.inputDatastream?.name || '—'
+              }}</span>
+              <span v-if="t.ratingCurve?.name" class="target-thing">
+                via {{ t.ratingCurve.name }}
+              </span>
+              <span class="target-id">{{ inputDatastreamId(t) || '—' }}</span>
+            </div>
+            <DatastreamSiteButton
+              :datastream="t.inputDatastream"
+              :datastream-id="inputDatastreamId(t)"
+              :fallback-thing-id="props.thingId"
+            />
           </div>
         </div>
 
@@ -26,12 +31,21 @@
         </div>
 
         <div class="rc-mapping-target">
-          <div class="etl-target-display">
-            <span class="target-name">{{ t.outputDatastream?.name || '—' }}</span>
-            <span v-if="outputThingName(t)" class="target-thing">
-              {{ outputThingName(t) }}
-            </span>
-            <span class="target-id">{{ t.outputDatastream?.id || '—' }}</span>
+          <div class="etl-target-display datastream-display">
+            <div class="datastream-display__content">
+              <span class="target-name">{{
+                t.outputDatastream?.name || '—'
+              }}</span>
+              <span v-if="outputThingName(t)" class="target-thing">
+                {{ outputThingName(t) }}
+              </span>
+              <span class="target-id">{{ outputDatastreamId(t) || '—' }}</span>
+            </div>
+            <DatastreamSiteButton
+              :datastream="t.outputDatastream"
+              :datastream-id="outputDatastreamId(t)"
+              :fallback-thing-id="props.thingId"
+            />
           </div>
         </div>
       </div>
@@ -42,26 +56,54 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import { mdiArrowRight } from '@mdi/js'
+import DatastreamSiteButton from '@/components/Orchestration/shared/DatastreamSiteButton.vue'
 import { useOrchestrationStore } from '@/store/orchestration'
+import { datastreamThingId } from '@/utils/orchestration/datastreams'
 
 type RatingCurveTransformation = {
   id?: string
-  inputDatastream?: { id?: string; name?: string; thingId?: string }
-  outputDatastream?: { id?: string; name?: string; thingId?: string }
+  inputDatastreamId?: string
+  outputDatastreamId?: string
+  inputDatastream?: {
+    id?: string
+    name?: string
+    thingId?: string
+    thing_id?: string
+    thing?: { id?: string }
+  }
+  outputDatastream?: {
+    id?: string
+    name?: string
+    thingId?: string
+    thing_id?: string
+    thing?: { id?: string }
+  }
   ratingCurve?: { id?: string; name?: string }
 }
 
 const props = defineProps<{
   transformations: RatingCurveTransformation[]
+  thingId?: string | null
 }>()
 
 const { workspaceThings } = storeToRefs(useOrchestrationStore())
 
+function inputDatastreamId(t: RatingCurveTransformation) {
+  return t.inputDatastream?.id || t.inputDatastreamId || ''
+}
+
+function outputDatastreamId(t: RatingCurveTransformation) {
+  return t.outputDatastream?.id || t.outputDatastreamId || ''
+}
+
 function outputThingName(t: RatingCurveTransformation) {
-  const ds = t.outputDatastream as any
-  const thingId = ds?.thingId ?? ds?.thing_id
+  const thingId =
+    (t.outputDatastream ? datastreamThingId(t.outputDatastream as any) : '') ||
+    props.thingId
   if (!thingId) return ''
-  return workspaceThings.value.find((th) => th.id === String(thingId))?.name || ''
+  return (
+    workspaceThings.value.find((th) => th.id === String(thingId))?.name || ''
+  )
 }
 </script>
 
@@ -137,6 +179,18 @@ function outputThingName(t: RatingCurveTransformation) {
   justify-content: center;
   text-align: left;
   overflow: hidden;
+}
+.datastream-display {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+.datastream-display__content {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 .target-id {
   color: rgba(0, 0, 0, 0.55);

--- a/apps/data-management/src/components/Orchestration/data-products/SimpleProductTaskDetails.vue
+++ b/apps/data-management/src/components/Orchestration/data-products/SimpleProductTaskDetails.vue
@@ -101,7 +101,7 @@
       </div>
     </header>
 
-    <v-tabs v-if="taskLabel === 'rating curve'" v-model="tab" density="compact">
+    <v-tabs v-model="tab" density="compact">
       <v-tab value="runs">Run history</v-tab>
       <v-tab value="mappings">Mappings</v-tab>
     </v-tabs>
@@ -117,8 +117,14 @@
         @copy="copy"
       />
       <RatingCurveSwimlanes
-        v-else
+        v-else-if="taskLabel === 'rating curve'"
         :transformations="task.ratingCurveTransformations ?? []"
+        :thing-id="task.thing?.id"
+      />
+      <ProductTaskSwimlanes
+        v-else
+        :task="task"
+        :task-label="taskLabel"
         :thing-id="task.thing?.id"
       />
     </section>
@@ -134,6 +140,7 @@ import AggregationForm from '@/components/Orchestration/data-products/Aggregatio
 import ExpressionForm from '@/components/Orchestration/data-products/ExpressionForm.vue'
 import DerivationForm from '@/components/Orchestration/data-products/DerivationForm.vue'
 import RatingCurveForm from '@/components/Orchestration/data-products/RatingCurveForm.vue'
+import ProductTaskSwimlanes from '@/components/Orchestration/data-products/ProductTaskSwimlanes.vue'
 import RatingCurveSwimlanes from '@/components/Orchestration/data-products/RatingCurveSwimlanes.vue'
 import TaskRunHistory from '@/components/Orchestration/shared/TaskRunHistory.vue'
 import { useSimpleTaskDetails } from '@/composables/orchestration/useSimpleTaskDetails'
@@ -217,7 +224,8 @@ function onFormUpdated() {
 }
 .bar {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: start;
   gap: 10px;
   padding: 14px 22px 12px;
   border-bottom: 1px solid #e8e8e8;
@@ -232,7 +240,8 @@ function onFormUpdated() {
 }
 .title {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  flex-wrap: wrap;
   gap: 10px;
   min-width: 0;
 }
@@ -255,11 +264,17 @@ h2 {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  align-items: flex-start;
+  align-self: start;
+  justify-content: flex-end;
+  justify-self: end;
 }
 .header-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  align-self: flex-start;
+  flex: 0 0 auto;
   gap: 8px;
   min-height: 34px;
   padding: 0 14px;
@@ -274,6 +289,7 @@ h2 {
   line-height: 1.1;
   transition: background-color 0.12s, border-color 0.12s, color 0.12s;
   white-space: nowrap;
+  width: auto;
 }
 .header-btn :deep(.v-icon) {
   flex: 0 0 auto;
@@ -315,5 +331,15 @@ h2 {
   padding: 40px 20px;
   text-align: center;
   color: #5f5a67;
+}
+
+@media (max-width: 760px) {
+  .bar {
+    grid-template-columns: 1fr;
+  }
+  .actions {
+    justify-self: start;
+    justify-content: flex-start;
+  }
 }
 </style>

--- a/apps/data-management/src/components/Orchestration/data-products/SimpleProductTaskDetails.vue
+++ b/apps/data-management/src/components/Orchestration/data-products/SimpleProductTaskDetails.vue
@@ -115,7 +115,6 @@
         highlighted-run-id=""
         @fetch-full="fetchRuns"
         @copy="copy"
-        @copy-run-link="() => null"
       />
       <RatingCurveSwimlanes
         v-else

--- a/apps/data-management/src/components/Orchestration/data-products/SimpleProductTaskDetails.vue
+++ b/apps/data-management/src/components/Orchestration/data-products/SimpleProductTaskDetails.vue
@@ -120,6 +120,7 @@
       <RatingCurveSwimlanes
         v-else
         :transformations="task.ratingCurveTransformations ?? []"
+        :thing-id="task.thing?.id"
       />
     </section>
   </div>

--- a/apps/data-management/src/components/Orchestration/data-products/SimpleProductTaskDetails.vue
+++ b/apps/data-management/src/components/Orchestration/data-products/SimpleProductTaskDetails.vue
@@ -106,16 +106,17 @@
       <v-tab value="mappings">Mappings</v-tab>
     </v-tabs>
     <section class="body">
-      <TaskRunHistory
-        v-if="tab === 'runs'"
-        :rows="runRows"
-        :show-loading="loadingRuns"
-        :has-loaded-full-run-history="true"
-        :loading-full-run-history="loadingRuns"
-        highlighted-run-id=""
-        @fetch-full="fetchRuns"
-        @copy="copy"
-      />
+      <div v-if="tab === 'runs'" class="run-history-list">
+        <TaskRunHistory
+          :rows="runRows"
+          :show-loading="loadingRuns"
+          :has-loaded-full-run-history="true"
+          :loading-full-run-history="loadingRuns"
+          highlighted-run-id=""
+          @fetch-full="fetchRuns"
+          @copy="copy"
+        />
+      </div>
       <RatingCurveSwimlanes
         v-else-if="taskLabel === 'rating curve'"
         :transformations="task.ratingCurveTransformations ?? []"
@@ -326,6 +327,11 @@ h2 {
   overflow: auto;
   padding: 16px 22px;
   background: #f5f7fa;
+}
+.run-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 .loading {
   padding: 40px 20px;

--- a/apps/data-management/src/components/Orchestration/ingestion/IngestionTaskDetails.vue
+++ b/apps/data-management/src/components/Orchestration/ingestion/IngestionTaskDetails.vue
@@ -113,7 +113,6 @@
           highlighted-run-id=""
           @fetch-full="fetchRuns"
           @copy="copy"
-          @copy-run-link="() => null"
         />
         <template v-else>
           <Swimlanes v-if="task.mappings?.length" :task="task" />

--- a/apps/data-management/src/components/Orchestration/ingestion/Swimlanes.vue
+++ b/apps/data-management/src/components/Orchestration/ingestion/Swimlanes.vue
@@ -3,10 +3,14 @@
     <div
       class="grid grid-cols-[minmax(0,1fr)_42px_minmax(0,2fr)] gap-[5px] items-center max-[960px]:grid-cols-1"
     >
-      <div class="font-extrabold uppercase tracking-[0.04em] text-[#4f4b59] text-[0.68rem] pb-1 col-start-1 col-end-2 max-[960px]:col-span-full">
+      <div
+        class="font-extrabold uppercase tracking-[0.04em] text-[#4f4b59] text-[0.68rem] pb-1 col-start-1 col-end-2 max-[960px]:col-span-full"
+      >
         Source field
       </div>
-      <div class="font-extrabold uppercase tracking-[0.04em] text-[#4f4b59] text-[0.68rem] pb-1 col-start-3 col-end-4 max-[960px]:col-span-full">
+      <div
+        class="font-extrabold uppercase tracking-[0.04em] text-[#4f4b59] text-[0.68rem] pb-1 col-start-3 col-end-4 max-[960px]:col-span-full"
+      >
         Target datastream
       </div>
 
@@ -28,20 +32,31 @@
 
           <div class="min-w-0 flex items-center">
             <div
-              class="etl-target-display w-full min-h-[40px] border border-[#d0c9d8] rounded-[10px] px-3 py-[6px] bg-[#f6f9ff] text-[0.86rem] text-[#1c1b1f] flex flex-col justify-center overflow-hidden"
+              class="etl-target-display w-full min-h-[40px] border border-[#d0c9d8] rounded-[10px] px-3 py-[6px] bg-[#f6f9ff] text-[0.86rem] text-[#1c1b1f] flex items-center gap-2 overflow-hidden"
             >
-              <span class="font-semibold text-[#1c1b1f] text-[0.86rem] leading-[1.25] [overflow-wrap:anywhere] whitespace-normal">
-                {{ resolveTargetName(m) || '—' }}
-              </span>
-              <span
-                v-if="resolveThingName(m)"
-                class="text-[rgba(0,0,0,0.66)] text-[0.78rem] mt-0.5 [overflow-wrap:anywhere] whitespace-normal"
-              >
-                {{ resolveThingName(m) }}
-              </span>
-              <span class="text-[rgba(0,0,0,0.55)] text-[0.72rem] mt-0.5 [overflow-wrap:anywhere] whitespace-normal">
-                {{ targetDatastream(m)?.id || '—' }}
-              </span>
+              <div class="min-w-0 flex flex-1 flex-col justify-center">
+                <span
+                  class="font-semibold text-[#1c1b1f] text-[0.86rem] leading-[1.25] [overflow-wrap:anywhere] whitespace-normal"
+                >
+                  {{ resolveTargetName(m) || '—' }}
+                </span>
+                <span
+                  v-if="resolveThingName(m)"
+                  class="text-[rgba(0,0,0,0.66)] text-[0.78rem] mt-0.5 [overflow-wrap:anywhere] whitespace-normal"
+                >
+                  {{ resolveThingName(m) }}
+                </span>
+                <span
+                  class="text-[rgba(0,0,0,0.55)] text-[0.72rem] mt-0.5 [overflow-wrap:anywhere] whitespace-normal"
+                >
+                  {{ targetDatastreamId(m) || '—' }}
+                </span>
+              </div>
+              <DatastreamSiteButton
+                :datastream="targetDatastream(m)"
+                :datastream-id="targetDatastreamId(m)"
+                :fallback-thing-id="resolveThingId(m)"
+              />
             </div>
           </div>
         </div>
@@ -54,7 +69,9 @@
 import { storeToRefs } from 'pinia'
 import type { TaskExpanded, TaskMapping } from '@hydroserver/client'
 import { mdiArrowRight } from '@mdi/js'
+import DatastreamSiteButton from '@/components/Orchestration/shared/DatastreamSiteButton.vue'
 import { useOrchestrationStore } from '@/store/orchestration'
+import { datastreamThingId } from '@/utils/orchestration/datastreams'
 
 const props = defineProps<{
   task: TaskExpanded
@@ -71,10 +88,15 @@ function targetDatastream(mapping: TaskMapping) {
   return 'targetDatastream' in mapping ? mapping.targetDatastream : null
 }
 
+function targetDatastreamId(mapping: TaskMapping) {
+  const datastream = targetDatastream(mapping)
+  return datastream?.id || (mapping as any).targetDatastreamId || ''
+}
+
 function resolveTargetName(mapping: TaskMapping) {
   const datastream = targetDatastream(mapping)
   if (datastream?.name) return datastream.name
-  const id = datastream?.id
+  const id = targetDatastreamId(mapping)
   if (!id) return ''
   const key = String(id)
   return (
@@ -86,17 +108,22 @@ function resolveTargetName(mapping: TaskMapping) {
 }
 
 function resolveThingName(mapping: TaskMapping) {
-  const ds = targetDatastream(mapping)
-  const dsId = ds?.id
-  const thingId =
-    ds?.thingId ??
-    ds?.thing_id ??
-    (dsId
-      ? workspaceDatastreams.value.find((d) => d.id === String(dsId))?.thingId
-      : null)
+  const thingId = resolveThingId(mapping)
   if (!thingId) return ''
-  return (
-    workspaceThings.value.find((t) => t.id === String(thingId))?.name || ''
-  )
+  return workspaceThings.value.find((t) => t.id === String(thingId))?.name || ''
+}
+
+function resolveThingId(mapping: TaskMapping) {
+  const ds = targetDatastream(mapping)
+  const dsId = targetDatastreamId(mapping)
+  const thingId = ds ? datastreamThingId(ds as any) : ''
+  if (thingId) return thingId
+  if (!dsId) return ''
+  const key = String(dsId)
+  const relatedDatastream =
+    workspaceDatastreams.value.find((d) => d.id === key) ||
+    linkedDatastreams.value.find((d) => d.id === key) ||
+    draftDatastreams.value.find((d) => String(d.id) === key)
+  return relatedDatastream ? datastreamThingId(relatedDatastream as any) : ''
 }
 </script>

--- a/apps/data-management/src/components/Orchestration/monitoring/QualityTaskDetails.vue
+++ b/apps/data-management/src/components/Orchestration/monitoring/QualityTaskDetails.vue
@@ -72,8 +72,14 @@
         </button>
       </div>
     </header>
+
+    <v-tabs v-model="tab" density="compact">
+      <v-tab value="runs">Run history</v-tab>
+      <v-tab value="mappings">Mappings</v-tab>
+    </v-tabs>
     <section class="body">
       <TaskRunHistory
+        v-if="tab === 'runs'"
         :rows="runRows"
         :show-loading="loadingRuns"
         :has-loaded-full-run-history="true"
@@ -82,23 +88,21 @@
         @fetch-full="fetchRuns"
         @copy="copy"
       />
+      <QualityTaskMappings v-else :task="task" :thing-id="task.thing?.id" />
     </section>
   </div>
   <div v-else class="loading">Loading...</div>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue'
 import DeleteTaskCard from '@/components/Orchestration/shared/DeleteTaskCard.vue'
 import NoScheduleIcon from '@/components/Orchestration/shared/NoScheduleIcon.vue'
 import QualityManagementForm from '@/components/Orchestration/monitoring/QualityManagementForm.vue'
+import QualityTaskMappings from '@/components/Orchestration/monitoring/QualityTaskMappings.vue'
 import TaskRunHistory from '@/components/Orchestration/shared/TaskRunHistory.vue'
 import { useSimpleTaskDetails } from '@/composables/orchestration/useSimpleTaskDetails'
-import {
-  mdiPause,
-  mdiPencil,
-  mdiPlay,
-  mdiTrashCanOutline,
-} from '@mdi/js'
+import { mdiPause, mdiPencil, mdiPlay, mdiTrashCanOutline } from '@mdi/js'
 
 const props = defineProps<{
   taskId: string
@@ -107,6 +111,7 @@ const props = defineProps<{
   initialTask?: any
 }>()
 const emit = defineEmits(['close', 'deleted', 'updated'])
+const tab = ref('runs')
 const {
   task,
   loadingRuns,

--- a/apps/data-management/src/components/Orchestration/monitoring/QualityTaskDetails.vue
+++ b/apps/data-management/src/components/Orchestration/monitoring/QualityTaskDetails.vue
@@ -27,7 +27,7 @@
               : 'Resume'
           }}</span>
         </button>
-        <v-dialog width="64rem">
+        <v-dialog v-model="editDialogOpen" width="64rem">
           <template #activator="{ props }">
             <button
               v-bind="props"
@@ -42,8 +42,8 @@
           <QualityManagementForm
             :initial-thing-id="task.thing.id"
             :edit-task-id="task.id"
-            @close="onUpdated"
-            @updated="onUpdated"
+            @close="closeEditDialog"
+            @updated="onFormUpdated"
             @deleted="deleteTask"
           />
         </v-dialog>
@@ -112,6 +112,7 @@ const props = defineProps<{
 }>()
 const emit = defineEmits(['close', 'deleted', 'updated'])
 const tab = ref('runs')
+const editDialogOpen = ref(false)
 const {
   task,
   loadingRuns,
@@ -130,6 +131,15 @@ const {
   runNow,
   togglePaused,
 } = useSimpleTaskDetails('monitoring', props, emit)
+
+function closeEditDialog() {
+  editDialogOpen.value = false
+}
+
+function onFormUpdated() {
+  closeEditDialog()
+  onUpdated()
+}
 </script>
 
 <style scoped>

--- a/apps/data-management/src/components/Orchestration/monitoring/QualityTaskDetails.vue
+++ b/apps/data-management/src/components/Orchestration/monitoring/QualityTaskDetails.vue
@@ -81,7 +81,6 @@
         highlighted-run-id=""
         @fetch-full="fetchRuns"
         @copy="copy"
-        @copy-run-link="() => null"
       />
     </section>
   </div>

--- a/apps/data-management/src/components/Orchestration/monitoring/QualityTaskMappings.vue
+++ b/apps/data-management/src/components/Orchestration/monitoring/QualityTaskMappings.vue
@@ -1,0 +1,183 @@
+<template>
+  <div class="quality-mappings-view">
+    <div v-if="mappingRows.length" class="quality-mappings">
+      <div class="quality-mappings-head">Target datastream</div>
+
+      <div
+        v-for="row in mappingRows"
+        :key="row.key"
+        class="quality-mapping-target"
+      >
+        <div class="datastream-display">
+          <div class="datastream-display__content">
+            <span class="target-name">{{ row.name }}</span>
+            <span v-if="row.thingName" class="target-thing">
+              {{ row.thingName }}
+            </span>
+            <span class="target-id">{{ row.id || '—' }}</span>
+          </div>
+          <DatastreamSiteButton
+            :datastream="row.datastream"
+            :datastream-id="row.id"
+            :fallback-thing-id="row.thingId"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div v-else class="empty-mappings">No mappings configured.</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import DatastreamSiteButton from '@/components/Orchestration/shared/DatastreamSiteButton.vue'
+import { useOrchestrationStore } from '@/store/orchestration'
+import { datastreamThingId } from '@/utils/orchestration/datastreams'
+
+type DatastreamLike = {
+  id?: string
+  name?: string
+  thingId?: string
+  thing_id?: string
+  thing?: { id?: string; name?: string }
+} | null
+
+const props = defineProps<{
+  task: any
+  thingId?: string | null
+}>()
+
+const {
+  linkedDatastreams,
+  workspaceDatastreams,
+  draftDatastreams,
+  workspaceThings,
+} = storeToRefs(useOrchestrationStore())
+
+const allKnownDatastreams = computed(() => [
+  ...workspaceDatastreams.value,
+  ...linkedDatastreams.value,
+  ...draftDatastreams.value,
+])
+
+const mappingRows = computed(() =>
+  (props.task?.monitoredDatastreams ?? []).map(
+    (monitoredDatastream: any, index: number) => {
+      const includedDatastream =
+        monitoredDatastream.datastream ?? monitoredDatastream
+      const id = String(
+        includedDatastream?.id ?? monitoredDatastream.datastreamId ?? ''
+      )
+      const datastream = resolveDatastream(includedDatastream, id)
+      const thingId =
+        (datastream ? datastreamThingId(datastream as any) : '') ||
+        props.thingId ||
+        ''
+
+      return {
+        key: id || `mapping-${index}`,
+        id,
+        datastream,
+        name: datastream?.name || id || '—',
+        thingId,
+        thingName:
+          (datastream as DatastreamLike)?.thing?.name ||
+          workspaceThings.value.find((thing) => thing.id === thingId)?.name ||
+          props.task?.thing?.name ||
+          '',
+      }
+    }
+  )
+)
+
+function resolveDatastream(datastream: DatastreamLike, id: string) {
+  if (datastream?.name) return datastream
+  if (!id) return datastream
+  return (
+    allKnownDatastreams.value.find(
+      (candidate) => String(candidate.id) === id
+    ) ?? datastream
+  )
+}
+</script>
+
+<style scoped>
+.quality-mappings-view {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.quality-mappings {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.quality-mappings-head {
+  padding-bottom: 4px;
+  color: #4f4b59;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.quality-mapping-target {
+  min-width: 0;
+}
+
+.datastream-display {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 40px;
+  overflow: hidden;
+  padding: 6px 12px;
+  border: 1px solid #d0c9d8;
+  border-radius: 8px;
+  background: #f6f9ff;
+  color: #1c1b1f;
+  font-size: 0.86rem;
+  text-align: left;
+}
+
+.datastream-display__content {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+}
+
+.target-name {
+  color: #1c1b1f;
+  font-size: 0.86rem;
+  font-weight: 600;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.target-thing {
+  margin-top: 2px;
+  color: rgba(0, 0, 0, 0.66);
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+}
+
+.target-id {
+  margin-top: 2px;
+  color: rgba(0, 0, 0, 0.55);
+  font-size: 0.72rem;
+  overflow-wrap: anywhere;
+}
+
+.empty-mappings {
+  padding: 10px 0;
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.86rem;
+}
+</style>

--- a/apps/data-management/src/components/Orchestration/shared/DatastreamSiteButton.vue
+++ b/apps/data-management/src/components/Orchestration/shared/DatastreamSiteButton.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="task-datastream-site-button">
+    <v-tooltip
+      :text="tooltipText"
+      location="top"
+      :open-delay="0"
+      :close-delay="0"
+    >
+      <template #activator="{ props: tooltipProps }">
+        <v-btn
+          v-bind="tooltipProps"
+          icon
+          size="x-small"
+          variant="text"
+          color="primary"
+          rounded="lg"
+          :to="siteRoute"
+          :disabled="!thingId"
+          :aria-label="ariaLabel"
+          :data-testid="testId"
+        >
+          <v-icon :icon="mdiMapMarker" size="16" />
+        </v-btn>
+      </template>
+    </v-tooltip>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { RouteLocationRaw } from 'vue-router'
+import type { Datastream } from '@hydroserver/client'
+import { mdiMapMarker } from '@mdi/js'
+import { datastreamThingId } from '@/utils/orchestration/datastreams'
+
+const props = withDefaults(
+  defineProps<{
+    datastream?: (Partial<Datastream> & Record<string, any>) | null
+    datastreamId?: string | null
+    fallbackThingId?: string | null
+  }>(),
+  {
+    datastream: null,
+    datastreamId: null,
+    fallbackThingId: null,
+  }
+)
+
+const datastreamId = computed(() => {
+  const id = props.datastreamId ?? props.datastream?.id
+  return id ? String(id) : ''
+})
+
+const thingId = computed(() => {
+  const fromDatastream = props.datastream
+    ? datastreamThingId(props.datastream as Datastream)
+    : ''
+  return fromDatastream || props.fallbackThingId || ''
+})
+
+const siteRoute = computed<RouteLocationRaw | undefined>(() =>
+  thingId.value
+    ? datastreamId.value
+      ? {
+          name: 'SiteDetails',
+          params: { id: thingId.value },
+          query: { datastream: datastreamId.value },
+        }
+      : { name: 'SiteDetails', params: { id: thingId.value } }
+    : undefined
+)
+
+const tooltipText = computed(() =>
+  thingId.value ? 'View site details' : 'Site details unavailable'
+)
+
+const ariaLabel = computed(() =>
+  thingId.value
+    ? `View site details for datastream ${datastreamId.value || 'mapping'}`
+    : 'Site details unavailable'
+)
+
+const testId = computed(() =>
+  datastreamId.value
+    ? `view-site-for-datastream-${datastreamId.value}`
+    : undefined
+)
+</script>
+
+<style scoped>
+.task-datastream-site-button {
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+</style>

--- a/apps/data-management/src/components/Orchestration/shared/DatastreamSiteButton.vue
+++ b/apps/data-management/src/components/Orchestration/shared/DatastreamSiteButton.vue
@@ -14,12 +14,13 @@
           variant="text"
           color="primary"
           rounded="lg"
+          class="task-datastream-site-button__button"
           :to="siteRoute"
           :disabled="!thingId"
           :aria-label="ariaLabel"
           :data-testid="testId"
         >
-          <v-icon :icon="mdiMapMarker" size="16" />
+          <v-icon :icon="mdiOpenInNew" size="16" />
         </v-btn>
       </template>
     </v-tooltip>
@@ -30,7 +31,7 @@
 import { computed } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
 import type { Datastream } from '@hydroserver/client'
-import { mdiMapMarker } from '@mdi/js'
+import { mdiOpenInNew } from '@mdi/js'
 import { datastreamThingId } from '@/utils/orchestration/datastreams'
 
 const props = withDefaults(
@@ -71,12 +72,12 @@ const siteRoute = computed<RouteLocationRaw | undefined>(() =>
 )
 
 const tooltipText = computed(() =>
-  thingId.value ? 'View site details' : 'Site details unavailable'
+  thingId.value ? 'Go to site details page' : 'Site details unavailable'
 )
 
 const ariaLabel = computed(() =>
   thingId.value
-    ? `View site details for datastream ${datastreamId.value || 'mapping'}`
+    ? `Go to site details page for datastream ${datastreamId.value || 'mapping'}`
     : 'Site details unavailable'
 )
 
@@ -90,6 +91,23 @@ const testId = computed(() =>
 <style scoped>
 .task-datastream-site-button {
   flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
   margin-left: auto;
+}
+
+.task-datastream-site-button__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.task-datastream-site-button__button :deep(.v-btn__content) {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
 }
 </style>

--- a/apps/data-management/src/components/Orchestration/shared/TaskRunHistory.vue
+++ b/apps/data-management/src/components/Orchestration/shared/TaskRunHistory.vue
@@ -101,7 +101,7 @@
                       </span>
                     </div>
                     <div class="run-entry-violation-meta">
-                      {{ violation.violationCount }} violation{{
+                      {{ violation.violationCount }} violating observation{{
                         violation.violationCount === 1 ? '' : 's'
                       }}
                       <span v-if="violation.firstViolationAt">

--- a/apps/data-management/src/components/Orchestration/shared/TaskRunHistory.vue
+++ b/apps/data-management/src/components/Orchestration/shared/TaskRunHistory.vue
@@ -46,7 +46,10 @@
           </div>
         </div>
 
-        <div class="run-entry-footer">
+        <div
+          v-if="run.runtimeUrl || run.violations.length"
+          class="run-entry-footer"
+        >
           <div class="run-entry-footer-content">
             <div v-if="run.runtimeUrl" class="run-entry-detail-row">
               <div class="run-entry-detail-label">Runtime source URI</div>

--- a/apps/data-management/src/components/Orchestration/shared/TaskRunHistory.vue
+++ b/apps/data-management/src/components/Orchestration/shared/TaskRunHistory.vue
@@ -112,27 +112,6 @@
                 </div>
               </div>
             </div>
-
-            <div class="run-entry-detail-row run-entry-detail-row-inline">
-              <div class="run-entry-detail-inline">
-                <div class="run-entry-detail-label">Copy run as URL</div>
-                <v-tooltip text="Copy run as URL" location="bottom">
-                  <template #activator="{ props: tooltipProps }">
-                    <v-btn
-                      v-bind="tooltipProps"
-                      icon
-                      variant="text"
-                      size="small"
-                      color="blue-grey-darken-2"
-                      aria-label="Copy run as URL"
-                      @click="$emit('copy-run-link', run.id)"
-                    >
-                      <v-icon :icon="mdiContentCopy" />
-                    </v-btn>
-                  </template>
-                </v-tooltip>
-              </div>
-            </div>
           </div>
         </div>
       </div>
@@ -189,7 +168,6 @@ defineProps<{
 defineEmits<{
   (e: 'fetch-full'): void
   (e: 'copy', value: string): void
-  (e: 'copy-run-link', runId: string): void
 }>()
 
 const shortId = (id: string) => {
@@ -350,17 +328,6 @@ const runDurationText = (run?: TaskRun | null) => {
   grid-template-columns: minmax(160px, 190px) 1fr;
   gap: 10px;
   align-items: start;
-}
-
-.run-entry-detail-row-inline {
-  grid-template-columns: 1fr;
-}
-
-.run-entry-detail-inline {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 8px;
 }
 
 .run-entry-detail-label {

--- a/apps/data-management/src/components/Sparkline.vue
+++ b/apps/data-management/src/components/Sparkline.vue
@@ -2,7 +2,7 @@
   <v-progress-linear v-if="loading" color="secondary" indeterminate />
   <div v-else-if="!loading && canShowSparkline">
     <div class="w-[300px] max-w-full max-[600px]:w-full">
-      <div class="mb-1 text-body-3 font-weight-light opacity-70">
+      <div class="sparkline-subtitle mb-1 font-weight-light opacity-70">
         Sparkline is showing most recent {{ validObservations.length }}
         values
       </div>
@@ -380,3 +380,10 @@ onBeforeUnmount(() => {
   // No cleanup required for SVG-based sparklines.
 })
 </script>
+
+<style scoped>
+.sparkline-subtitle {
+  font-size: 0.9rem;
+  line-height: 1.25;
+}
+</style>

--- a/apps/data-management/src/composables/useMetadata.ts
+++ b/apps/data-management/src/composables/useMetadata.ts
@@ -43,6 +43,9 @@ export function useMetadata(localWorkspace?: Ref<Workspace | undefined>) {
   )
 
   const fetchMetadata = async (id: string | null) => {
+    const workspaceFilter = id
+      ? { workspace_id: [id, 'null'] as (string | 'null')[] }
+      : {}
     try {
       const [
         unitsResponse,
@@ -51,11 +54,20 @@ export function useMetadata(localWorkspace?: Ref<Workspace | undefined>) {
         sensorsResponse,
         resultQualifiersResponse,
       ] = await Promise.all([
-        hs.units.listAllItems({ order_by: ['name'] }),
-        hs.observedProperties.listAllItems({ order_by: ['name'] }),
-        hs.processingLevels.listAllItems({ order_by: ['code'] }),
-        hs.sensors.listAllItems({ order_by: ['name'] }),
-        hs.resultQualifiers.listAllItems({ order_by: ['code'] }),
+        hs.units.listAllItems({ order_by: ['name'], ...workspaceFilter }),
+        hs.observedProperties.listAllItems({
+          order_by: ['name'],
+          ...workspaceFilter,
+        }),
+        hs.processingLevels.listAllItems({
+          order_by: ['code'],
+          ...workspaceFilter,
+        }),
+        hs.sensors.listAllItems({ order_by: ['name'], ...workspaceFilter }),
+        hs.resultQualifiers.listAllItems({
+          order_by: ['code'],
+          ...workspaceFilter,
+        }),
       ])
 
       units.value = unitsResponse.filter(

--- a/apps/data-management/src/composables/useWorkspacePermissions.ts
+++ b/apps/data-management/src/composables/useWorkspacePermissions.ts
@@ -37,7 +37,7 @@ export function useWorkspacePermissions(
   }
 
   function isAdmin() {
-    return user.value.accountType === 'admin'
+    return user.value?.accountType === 'admin'
   }
   const getUserRoleName = (workspace: Workspace): string => {
     if (isOwner(workspace)) return 'Owner'

--- a/apps/data-management/src/pages/SiteDetails.vue
+++ b/apps/data-management/src/pages/SiteDetails.vue
@@ -183,11 +183,14 @@
         <div v-else class="text-body-2 text-medium-emphasis">
           No photos added yet.
         </div>
-
       </v-col>
     </v-row>
 
-    <DatastreamTable v-if="thing && workspace" :workspace="workspace" />
+    <DatastreamTable
+      v-if="thing && workspace"
+      :workspace="workspace"
+      :target-datastream-id="targetDatastreamId"
+    />
 
     <v-dialog v-model="isPhotoViewerOpen" width="60rem">
       <v-card v-if="selectedPhoto">
@@ -263,7 +266,12 @@ import HydroShareArchivalButton from '@/components/HydroShare/HydroShareArchival
 import { mdiChevronLeft, mdiChevronRight } from '@mdi/js'
 import { useDisplay } from 'vuetify/lib/framework.mjs'
 
-const thingId = useRoute().params.id.toString()
+const route = useRoute()
+const thingId = route.params.id.toString()
+const targetDatastreamId = computed(() => {
+  const param = route.query.datastream
+  return Array.isArray(param) ? param[0] ?? '' : `${param ?? ''}`
+})
 const { photos, loading } = storeToRefs(usePhotosStore())
 const workspace = ref<Workspace>()
 

--- a/apps/data-management/src/pages/__tests__/TaskDetailComponents.spec.ts
+++ b/apps/data-management/src/pages/__tests__/TaskDetailComponents.spec.ts
@@ -136,6 +136,16 @@ const makeEtlTask = () => ({
   },
 })
 
+const makeMonitoringTask = () => ({
+  id: 'monitoring-task-1',
+  name: 'Quality task',
+  description: null,
+  thing: { id: 'thing-1', name: 'Site 1', workspaceId: 'workspace-1' },
+  monitoredDatastreams: [],
+  latestRun: null,
+  schedule: null,
+})
+
 const globalStubs = {
   'v-dialog': {
     props: ['modelValue'],
@@ -154,6 +164,10 @@ const globalStubs = {
   IngestionTaskForm: {
     props: ['oldTask', 'dataConnection', 'workspaceId'],
     template: '<div class="task-form-stub" />',
+  },
+  QualityManagementForm: {
+    emits: ['close', 'updated', 'deleted'],
+    template: '<div class="quality-form-stub" />',
   },
 }
 
@@ -186,6 +200,10 @@ describe('Task detail components', () => {
     dataProductUpdateMock.mockResolvedValue({
       ok: true,
       data: makeDataProductTask(),
+    })
+    monitoringGetMock.mockResolvedValue({
+      ok: true,
+      data: makeMonitoringTask(),
     })
   })
 
@@ -263,5 +281,29 @@ describe('Task detail components', () => {
       expand_related: true,
     })
     expect(wrapper.text()).toContain('Ingestion task')
+  })
+
+  it('closes the quality edit dialog after a successful update', async () => {
+    const { default: QualityTaskDetails } = await import(
+      '@/components/Orchestration/monitoring/QualityTaskDetails.vue'
+    )
+    await seedWorkspace()
+
+    const wrapper = shallowMount(QualityTaskDetails as any, {
+      props: {
+        taskId: 'monitoring-task-1',
+        embedded: true,
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+    await flushPromises()
+    ;(wrapper.vm as any).editDialogOpen = true
+    ;(wrapper.vm as any).onFormUpdated()
+    await flushPromises()
+
+    expect((wrapper.vm as any).editDialogOpen).toBe(false)
+    expect(monitoringGetMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/data-management/src/store/workspaces.ts
+++ b/apps/data-management/src/store/workspaces.ts
@@ -22,7 +22,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
 
   const ownedWorkspaces = computed(() =>
     workspaces.value.filter(
-      (ws) => !!ws.owner && ws.owner.email === user.value.email
+      (ws) => !!ws.owner && ws.owner.email === user.value?.email
     )
   )
 

--- a/apps/data-management/src/utils/__tests__/datastreams.spec.ts
+++ b/apps/data-management/src/utils/__tests__/datastreams.spec.ts
@@ -7,6 +7,9 @@ import {
 describe('datastream orchestration helpers', () => {
   it('resolves thing ids from lean or expanded datastreams', () => {
     expect(datastreamThingId({ thingId: 'thing-1' } as any)).toBe('thing-1')
+    expect(datastreamThingId({ thing_id: 'thing-snake' } as any)).toBe(
+      'thing-snake'
+    )
     expect(datastreamThingId({ thing: { id: 'thing-2' } } as any)).toBe(
       'thing-2'
     )
@@ -17,13 +20,13 @@ describe('datastream orchestration helpers', () => {
     const datastreams = [
       { id: 'ds-1', thingId: 'thing-1' },
       { id: 'ds-2', thing: { id: 'thing-1' } },
+      { id: 'ds-snake', thing_id: 'thing-1' },
       { id: 'ds-3', thingId: 'thing-2' },
     ] as any[]
 
     expect(datastreamsForThing(datastreams, null)).toEqual([])
-    expect(datastreamsForThing(datastreams, 'thing-1').map((d) => d.id)).toEqual([
-      'ds-1',
-      'ds-2',
-    ])
+    expect(
+      datastreamsForThing(datastreams, 'thing-1').map((d) => d.id)
+    ).toEqual(['ds-1', 'ds-2', 'ds-snake'])
   })
 })

--- a/apps/data-management/src/utils/__tests__/taskRunDetails.spec.ts
+++ b/apps/data-management/src/utils/__tests__/taskRunDetails.spec.ts
@@ -239,6 +239,25 @@ describe('task run detail helpers', () => {
     expect(getTaskRunStatusText(run)).toBe('Needs attention')
   })
 
+  it('counts distinct violated rules instead of violating observations', () => {
+    const run: TaskRun = {
+      id: 'run-monitoring-counts',
+      status: 'SUCCESS',
+      result: {
+        rulesViolated: 3,
+        violations: [
+          {
+            ruleType: 'range',
+            violationCount: 3,
+          },
+        ],
+      },
+    }
+
+    expect(getMonitoringRulesViolated(run)).toBe(1)
+    expect(getTaskRunStatusText(run)).toBe('Needs attention')
+  })
+
   it('maps task run statuses for UI display', () => {
     expect(
       getTaskRunStatusText({

--- a/apps/data-management/src/utils/orchestration/datastreams.ts
+++ b/apps/data-management/src/utils/orchestration/datastreams.ts
@@ -1,9 +1,11 @@
 import type { Datastream } from '@hydroserver/client'
 
 export function datastreamThingId(datastream: Datastream): string {
-  const expandedThingId = (datastream as Datastream & { thing?: { id?: string } })
-    .thing?.id
-  return datastream.thingId || expandedThingId || ''
+  const ds = datastream as Datastream & {
+    thing?: { id?: string }
+    thing_id?: string
+  }
+  return datastream.thingId || ds.thing_id || ds.thing?.id || ''
 }
 
 export function datastreamsForThing(
@@ -11,5 +13,7 @@ export function datastreamsForThing(
   thingId: string | null | undefined
 ) {
   if (!thingId) return []
-  return datastreams.filter((datastream) => datastreamThingId(datastream) === thingId)
+  return datastreams.filter(
+    (datastream) => datastreamThingId(datastream) === thingId
+  )
 }

--- a/apps/data-management/src/utils/orchestration/taskRunDetails.ts
+++ b/apps/data-management/src/utils/orchestration/taskRunDetails.ts
@@ -241,15 +241,6 @@ export const getTaskRunRuntimeUrl = (run?: TaskRun | null) => {
   )
 }
 
-export const getMonitoringRulesViolated = (run?: TaskRun | null) => {
-  const result = getTaskRunResult(run)
-  const count = firstNumber(result.rulesViolated, result.rules_violated)
-  if (count !== undefined) return count
-
-  const violations = result.violations
-  return Array.isArray(violations) ? violations.length : 0
-}
-
 export const getMonitoringRunViolations = (
   run?: TaskRun | null
 ): MonitoringRunViolation[] => {
@@ -274,6 +265,29 @@ export const getMonitoringRunViolations = (
         entry.last_violation_at
       ),
     }))
+}
+
+export const countDistinctMonitoringViolationRules = (
+  violations: MonitoringRunViolation[]
+) =>
+  new Set(
+    violations.map((violation, index) => {
+      if (violation.ruleId) return violation.ruleId
+      const compositeKey = [violation.datastreamId, violation.ruleType]
+        .filter(Boolean)
+        .join(':')
+      return compositeKey || `violation-${index}`
+    })
+  ).size
+
+export const getMonitoringRulesViolated = (run?: TaskRun | null) => {
+  const violations = getMonitoringRunViolations(run)
+  if (violations.length) {
+    return countDistinctMonitoringViolationRules(violations)
+  }
+
+  const result = getTaskRunResult(run)
+  return firstNumber(result.rulesViolated, result.rules_violated) ?? 0
 }
 
 export const taskRunHasFailures = (run?: TaskRun | null) => {

--- a/apps/qc-app/package-lock.json
+++ b/apps/qc-app/package-lock.json
@@ -58,7 +58,7 @@
     },
     "../../packages/hydroserver-ts": {
       "name": "@hydroserver/client",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.0-beta.3",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@types/node": "^24.1.0",

--- a/django/contracts/openapi/data.openapi.json
+++ b/django/contracts/openapi/data.openapi.json
@@ -4245,6 +4245,16 @@
             "description": "The number of items per page.",
             "title": "Page Size"
           },
+          "thing_id": {
+            "default": [],
+            "description": "Filter ETL tasks by thing ID.",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "title": "Thing Id",
+            "type": "array"
+          },
           "workspace_id": {
             "default": [],
             "description": "Filter ETL tasks by workspace ID.",
@@ -15257,6 +15267,22 @@
                 "type": "string"
               },
               "title": "Order By",
+              "type": "array"
+            }
+          },
+          {
+            "description": "Filter ETL tasks by thing ID.",
+            "in": "query",
+            "name": "thing_id",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Filter ETL tasks by thing ID.",
+              "items": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "title": "Thing Id",
               "type": "array"
             }
           },

--- a/django/contracts/openapi/data.openapi.json
+++ b/django/contracts/openapi/data.openapi.json
@@ -5816,6 +5816,56 @@
         "title": "NotificationResponse",
         "type": "object"
       },
+      "ObservationBulkColumnarPostBody": {
+        "properties": {
+          "phenomenonTime": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "format": "date-time",
+                  "type": "string"
+                }
+              ]
+            },
+            "title": "Phenomenontime",
+            "type": "array"
+          },
+          "result": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": "Result",
+            "type": "array"
+          },
+          "resultQualifierCodes": {
+            "default": [],
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "title": "Resultqualifiercodes",
+            "type": "array"
+          }
+        },
+        "required": [
+          "phenomenonTime",
+          "result"
+        ],
+        "title": "ObservationBulkColumnarPostBody",
+        "type": "object"
+      },
       "ObservationBulkDeleteBody": {
         "properties": {
           "phenomenonTimeEnd": {
@@ -14036,7 +14086,15 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ObservationBulkPostBody"
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ObservationBulkPostBody"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ObservationBulkColumnarPostBody"
+                  }
+                ],
+                "title": "Data"
               }
             }
           },

--- a/django/interfaces/api/schemas/etl/task.py
+++ b/django/interfaces/api/schemas/etl/task.py
@@ -33,6 +33,9 @@ class EtlTaskQueryParameters(CollectionQueryParameters):
     order_by: list[EtlTaskOrderBy] = Query(
         [], description="Select one or more fields to order the response by."
     )
+    thing_id: list[uuid.UUID] = Query(
+        [], description="Filter ETL tasks by thing ID."
+    )
     workspace_id: list[uuid.UUID] = Query(
         [], description="Filter ETL tasks by workspace ID."
     )

--- a/django/interfaces/api/views/etl/task.py
+++ b/django/interfaces/api/views/etl/task.py
@@ -48,10 +48,11 @@ def get_etl_tasks(
             principal=request.principal,
             order_by=[f.orm_field for f in query.order_by],
             **query.model_dump(exclude_unset=True, exclude={
-                "order_by", "workspace_id", "data_connection_id",
+                "order_by", "thing_id", "workspace_id", "data_connection_id",
                 "latest_run_started_at_min", "latest_run_started_at_max",
                 "latest_run_finished_at_min", "latest_run_finished_at_max",
             }),
+            **({"thing": query.thing_id} if "thing_id" in query.model_fields_set else {}),
             **({"workspace": query.workspace_id} if "workspace_id" in query.model_fields_set else {}),
             **({"data_connection": query.data_connection_id}
                if "data_connection_id" in query.model_fields_set else {}),

--- a/django/processing/etl/services/task.py
+++ b/django/processing/etl/services/task.py
@@ -12,6 +12,7 @@ from django.contrib.postgres.search import SearchVector, SearchQuery
 from core.types import Unset
 from core.iam.models import APIKey, Workspace
 from core.service import ServiceUtils
+from core.sta.models import Thing
 from core.sta.services import DatastreamService
 from processing.orchestration.services import TaskService
 from processing.etl.models import EtlTask, EtlMapping, DataConnection
@@ -73,6 +74,7 @@ class EtlTaskService(TaskService[EtlTask], ServiceUtils):
         page_size: int = Field(gt=0, default=100),
         order_by: list[str] = Field(default_factory=list),
         search_term: str | Unset = Unset,
+        thing: list[uuid.UUID | Thing] | Unset = Unset,
         workspace: list[uuid.UUID | Workspace] | Unset = Unset,
         data_connection: list[uuid.UUID | DataConnection] | Unset = Unset,
         latest_run_status: list[str] | Unset = Unset,
@@ -100,6 +102,11 @@ class EtlTaskService(TaskService[EtlTask], ServiceUtils):
         if search_term is not Unset:
             search_vector = SearchVector("name", "description", "data_connection__name")
             queryset = queryset.annotate(search=search_vector).filter(search=SearchQuery(search_term))
+
+        if thing is not Unset:
+            queryset = queryset.filter(etl_mappings__target_datastream__thing__in=[
+                getattr(t, "pk", t) for t in thing
+            ])
 
         if workspace is not Unset:
             queryset = queryset.filter(data_connection__workspace__in=[

--- a/django/tests/etl/services/test_etl_task.py
+++ b/django/tests/etl/services/test_etl_task.py
@@ -12,6 +12,8 @@ DC1 = "019adb5c-da8b-7970-877d-c3b4ca37cc60"    # private workspace
 DC2 = "019bbd9d-ee62-7669-8db0-3ef50802f1d8"    # public workspace
 PRIVATE_WORKSPACE = "b27c51a0-7374-462d-8a53-d97d47176c10"
 PUBLIC_WORKSPACE = "6e0deaf2-a92b-421b-9ece-86783265596f"
+PRIVATE_WS_THING = "819260c8-2543-4046-b8c4-7431243ed7c5"  # thing that DS_PRIVATE_WS belongs to (mapped by TASK1)
+PUBLIC_WS_THING = "3b7818af-eff7-4149-8517-e5cad9dc22e1"   # thing in public workspace (no ETL mapping)
 DS_PRIVATE_WS = "dd1f9293-ce29-4b6a-88e6-d65110d1be65"   # public datastream, public thing, private workspace (mapped by TASK1)
 DS_PRIVATE_WS_2 = "1c9a797e-6fd8-4e99-b1ae-87ab4affc0a2"  # private datastream, public thing, private workspace
 DS_PUBLIC_WS = "27c70b41-e845-40ea-8cc7-d1b40f89816b"   # public datastream, public thing, public workspace
@@ -39,6 +41,9 @@ NONEXISTENT = "00000000-0000-0000-0000-000000000000"
         # Data connection filter
         ("owner", {"data_connection": [uuid.UUID(DC1)]}, ["Test ETL Task"], 10),
         ("owner", {"data_connection": [uuid.UUID(DC2)]}, [], 10),
+        # Thing filter (via ETL mapping → target datastream → thing)
+        ("owner", {"thing": [uuid.UUID(PRIVATE_WS_THING)]}, ["Test ETL Task"], 10),
+        ("owner", {"thing": [uuid.UUID(PUBLIC_WS_THING)]}, [], 10),
     ],
 )
 def test_list_etl_tasks(

--- a/package-lock.json
+++ b/package-lock.json
@@ -9665,7 +9665,7 @@
     },
     "packages/hydroserver-ts": {
       "name": "@hydroserver/client",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.0-beta.3",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@types/node": "^24.1.0",

--- a/packages/hydroserver-ts/package-lock.json
+++ b/packages/hydroserver-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hydroserver/client",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hydroserver/client",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.0-beta.3",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@types/node": "^24.1.0",

--- a/packages/hydroserver-ts/package.json
+++ b/packages/hydroserver-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydroserver/client",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "HydroServer TypeScript client",
   "type": "module",
   "main": "dist/@hydroserver-client.umd.cjs",

--- a/packages/hydroserver-ts/src/generated/data.types.d.ts
+++ b/packages/hydroserver-ts/src/generated/data.types.d.ts
@@ -4022,6 +4022,18 @@ export interface components {
             recipientEmails: string[];
             schedule?: components["schemas"]["ScheduleResponse"] | null;
         };
+        /** ObservationBulkColumnarPostBody */
+        ObservationBulkColumnarPostBody: {
+            /** Phenomenontime */
+            phenomenonTime: (string)[];
+            /** Result */
+            result: (number | null)[];
+            /**
+             * Resultqualifiercodes
+             * @default []
+             */
+            resultQualifierCodes: string[][];
+        };
         /** ObservationBulkDeleteBody */
         ObservationBulkDeleteBody: {
             /** Phenomenontimeend */
@@ -6916,7 +6928,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ObservationBulkPostBody"];
+                "application/json": components["schemas"]["ObservationBulkPostBody"] | components["schemas"]["ObservationBulkColumnarPostBody"];
             };
         };
         responses: {

--- a/packages/hydroserver-ts/src/generated/data.types.d.ts
+++ b/packages/hydroserver-ts/src/generated/data.types.d.ts
@@ -3493,6 +3493,12 @@ export interface components {
              */
             page_size: number | null;
             /**
+             * Thing Id
+             * @description Filter ETL tasks by thing ID.
+             * @default []
+             */
+            thing_id: string[];
+            /**
              * Workspace Id
              * @description Filter ETL tasks by workspace ID.
              * @default []
@@ -7574,6 +7580,8 @@ export interface operations {
                 page_size?: number | null;
                 /** @description Select one or more fields to order the response by. */
                 order_by?: ("id" | "name" | "dataConnectionId" | "dataConnectionName" | "workspaceId" | "workspaceName" | "latestRunStatus" | "latestRunStartedAt" | "latestRunFinishedAt" | "-id" | "-name" | "-dataConnectionId" | "-dataConnectionName" | "-workspaceId" | "-workspaceName" | "-latestRunStatus" | "-latestRunStartedAt" | "-latestRunFinishedAt")[];
+                /** @description Filter ETL tasks by thing ID. */
+                thing_id?: string[];
                 /** @description Filter ETL tasks by workspace ID. */
                 workspace_id?: string[];
                 /** @description Filter ETL tasks by data connection ID. */


### PR DESCRIPTION
Resolves #405. 

Added a task information bar to the bottom of each datastream list item on the SiteDetails.vue page. This provides an overview of task status for all types of tasks including quality monitoring tasks. It also displays a loud error state in the bar if a datastream is being fed by more than one task. 

Added a reverse link that routes the user from the job orchestration page's mappings view to the SiteDetails page. This is deep linked and will scroll the page down the datastream of interest.

@kjlippold I optimized the frontend to fetch tasks in parallel and added a skeleton loader so tasks to block the page load, but there's still quite a bit of over-fetching since the page needs to request every task for the entire workspace. The final version of this should probably provide some API filters that will fetch only the tasks relevant to the monitoring site and possibly a backend-for-frontend endpoint to collapse the parallel requests per page visit into one. My local instance takes 4-5 seconds to load tasks. 

<img width="1403" height="975" alt="Screenshot 2026-06-24 at 11 34 41 AM" src="https://github.com/user-attachments/assets/e414f6cd-c5d4-4f06-88ef-1284f7e89305" />
