### PR TITLE
Added socket_timeout to CELERY_BROKER_TRANSPORT_OPTIONS

### DIFF
--- a/django/hydroserver/settings.py
+++ b/django/hydroserver/settings.py
@@ -91,6 +91,7 @@ CELERY_BROKER_HEARTBEAT = 10
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     "socket_keepalive": True,
     "retry_on_timeout": True,
+    "socket_timeout": 30,
 }
 
 DATA_CONNECTION_NOTIFICATION_CRONTAB = config("DATA_CONNECTION_NOTIFICATION_CRONTAB", default="0 0 * * *").split()


### PR DESCRIPTION
Added socket_timeout to CELERY_BROKER_TRANSPORT_OPTIONS to try to fix issue with Celery worker disconnecting from Redis and not recovering in GCP.