### PR TITLE
421 description

### DIFF
--- a/apps/data-management/src/components/Orchestration/connections/DataConnectionForm.vue
+++ b/apps/data-management/src/components/Orchestration/connections/DataConnectionForm.vue
@@ -37,7 +37,7 @@
             color="primary"
             density="compact"
             hide-details
-            label="Advanced features"
+            label="Use advanced features"
           />
 
           <div v-if="advancedFeaturesEnabled" class="advanced-features-body">

--- a/apps/data-management/src/components/Orchestration/connections/DataConnectionForm.vue
+++ b/apps/data-management/src/components/Orchestration/connections/DataConnectionForm.vue
@@ -41,6 +41,16 @@
           />
 
           <div v-if="advancedFeaturesEnabled" class="advanced-features-body">
+            <p class="font-weight-bold mb-2">Description</p>
+            <v-textarea
+              v-model="formDataConnection.description"
+              label="Data connection description"
+              :rules="rules.description"
+              rows="3"
+              auto-grow
+              density="compact"
+            />
+
             <p class="font-weight-bold mb-2">Authentication header</p>
             <div class="auth-header-grid">
               <v-combobox
@@ -228,6 +238,7 @@ function hasAdvancedFeatures(dataConnection?: DataConnection) {
   if (!dataConnection) return false
 
   return !!(
+    toRecipientString(dataConnection.description) ||
     toRecipientString(dataConnection.authHeaderName) ||
     toRecipientString(dataConnection.authHeaderValue) ||
     (dataConnection as any).notification?.recipientEmails?.length
@@ -338,15 +349,18 @@ async function onSubmit() {
 
 function normalizeAdvancedFields(dataConnection: DataConnection) {
   if (!advancedFeaturesEnabled.value) {
+    dataConnection.description = null
     dataConnection.authHeaderName = null
     dataConnection.authHeaderValue = null
     dataConnection.notification = null
     return
   }
 
+  const description = `${dataConnection.description ?? ''}`.trim()
   const authHeaderName = `${dataConnection.authHeaderName ?? ''}`.trim()
   const authHeaderValue = `${dataConnection.authHeaderValue ?? ''}`.trim()
 
+  dataConnection.description = description || null
   dataConnection.authHeaderName = authHeaderName || null
   dataConnection.authHeaderValue = authHeaderValue || null
 


### PR DESCRIPTION
Resolves #421 

I put description in the 'advanced features' section of the form since I'd like to keep the form short and simple for beginner users. 

Additionally, I updated the label for advanced features to 'Use advanced features' since before it wasn't clear that those fields are all set to null when the toggle is turned off. 