### PR TITLE
415 large data

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -111,6 +111,43 @@
       "problemMatcher": []
     },
     {
+      "label": "Start Data Management App (Utah Water Rights Test)",
+      "type": "shell",
+      "command": "npm run dev",
+      "options": {
+        "cwd": "${workspaceFolder}/apps/data-management",
+        "env": {
+          "VITE_APP_PROXY_BASE_URL": "https://hydroservertest.waterrights.utah.gov",
+          "VITE_HYDROSERVER_CLIENT_LOCAL": "1",
+          "VITE_HYDROSERVER_CLIENT_PATH": "${workspaceFolder}/packages/hydroserver-ts/src"
+        }
+      },
+      "presentation": {
+        "group": "utah-water-rights-test",
+        "panel": "dedicated",
+        "reveal": "always"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Start QC App (Utah Water Rights Test)",
+      "type": "shell",
+      "command": "npm run dev:qc",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VITE_APP_PROXY_BASE_URL": "https://hydroservertest.waterrights.utah.gov",
+          "VITE_APP_DISABLE_COOP": "1"
+        }
+      },
+      "presentation": {
+        "group": "utah-water-rights-test",
+        "panel": "dedicated",
+        "reveal": "always"
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "Start Backend",
       "type": "shell",
       "command": "${workspaceFolder}/scripts/dev-api-command manage.py runserver 0.0.0.0:8000",
@@ -182,6 +219,15 @@
       "dependsOn": [
         "Start Data Management App (Utah Water Rights Dev)",
         "Start QC App (Utah Water Rights Dev)"
+      ],
+      "dependsOrder": "parallel",
+      "problemMatcher": []
+    },
+    {
+      "label": "Start Frontends Against Utah Water Rights Test",
+      "dependsOn": [
+        "Start Data Management App (Utah Water Rights Test)",
+        "Start QC App (Utah Water Rights Test)"
       ],
       "dependsOrder": "parallel",
       "problemMatcher": []

--- a/apps/data-management/src/components/Datastream/DatastreamPopupPlot.vue
+++ b/apps/data-management/src/components/Datastream/DatastreamPopupPlot.vue
@@ -88,7 +88,11 @@
 <script setup lang="ts">
 import { Datastream, GraphSeries } from '@hydroserver/client'
 import DatePickerField from '@/components/VisualizeData/DatePickerField.vue'
-import { createPlotlyOption, PlotlyOptions } from '@/utils/plotting/plotly'
+import {
+  createPlotlyOption,
+  PlotlyOptions,
+  supportsWebgl,
+} from '@/utils/plotting/plotly'
 import { onMounted, ref, nextTick, onBeforeUnmount, computed } from 'vue'
 import { debounce } from 'lodash-es'
 import { useObservationStore } from '@/store/observations'
@@ -128,7 +132,11 @@ const ensurePlotly = async () => {
   return plotlyApi
 }
 
-const LARGE_SERIES_VISIBLE_THRESHOLD = 50_000
+// scattergl (WebGL) draws markers on the GPU and stays usable into the
+// hundreds of thousands of visible points, so we push close to that bound.
+// Without WebGL, Plotly falls back to SVG markers, which choke at a few
+// thousand — so cap far lower in that case.
+const LARGE_SERIES_VISIBLE_THRESHOLD = supportsWebgl() ? 200_000 : 5_000
 const LARGE_SERIES_TOTAL_THRESHOLD = 200_000
 const DEFAULT_HOVER_TEMPLATE = '<b>%{y}</b><extra></extra>'
 const isLargeSeriesMode = ref(false)

--- a/apps/data-management/src/components/Datastream/DatastreamPopupPlot.vue
+++ b/apps/data-management/src/components/Datastream/DatastreamPopupPlot.vue
@@ -90,6 +90,7 @@ import { Datastream, GraphSeries } from '@hydroserver/client'
 import DatePickerField from '@/components/VisualizeData/DatePickerField.vue'
 import { createPlotlyOption, PlotlyOptions } from '@/utils/plotting/plotly'
 import { onMounted, ref, nextTick, onBeforeUnmount, computed } from 'vue'
+import { debounce } from 'lodash-es'
 import { useObservationStore } from '@/store/observations'
 import { mdiArrowRight } from '@mdi/js'
 
@@ -222,34 +223,37 @@ const normalizeTraceArray = <T,>(
 const applyLargeSeriesMode = async (visiblePoints: number) => {
   if (!plotlyRef.value || !plotlyApi) return
   const totalPoints = getTotalPointCount()
+  // Markers are a viewport concern: hide them only when the *visible* window is
+  // too dense to draw meaningfully, so zooming into a sparse window restores
+  // them even on a huge series (scattergl draws markers on the GPU). Hover stays
+  // gated on the total point count.
+  const hideMarkers = visiblePoints > LARGE_SERIES_VISIBLE_THRESHOLD
   const forceLargeMode = totalPoints > LARGE_SERIES_TOTAL_THRESHOLD
-  const shouldEnable =
-    visiblePoints > LARGE_SERIES_VISIBLE_THRESHOLD || forceLargeMode
 
   const traceCount = plotlyRef.value.data?.length ?? 0
   if (!traceCount) return
   const needsEnforcement =
-    shouldEnable &&
+    hideMarkers &&
     plotlyRef.value.data?.some((trace: any) => {
       if (trace?.mode !== 'lines') return true
       const size = trace?.marker?.size
       return typeof size === 'number' ? size !== 0 : false
     })
 
-  const nextModes = shouldEnable
+  const nextModes = hideMarkers
     ? new Array(traceCount).fill('lines')
     : normalizeTraceArray(defaultTraceModes.value, traceCount, 'lines+markers')
-  const nextMarkerSizes = shouldEnable
+  const nextMarkerSizes = hideMarkers
     ? new Array(traceCount).fill(0)
     : normalizeTraceArray(defaultMarkerSizes.value, traceCount, 6)
-  const nextHoverInfo: 'y' | 'skip' = shouldEnable ? 'skip' : 'y'
+  const nextHoverInfo: 'y' | 'skip' = hideMarkers ? 'skip' : 'y'
   const nextHoverMode = forceLargeMode ? false : defaultHoverMode.value
   const traceCountChanged = traceCount !== lastStyledTraceCount.value
 
   if (
     traceCountChanged ||
     needsEnforcement ||
-    shouldEnable !== isLargeSeriesMode.value ||
+    hideMarkers !== isLargeSeriesMode.value ||
     nextHoverInfo !== currentHoverInfo.value
   ) {
     const nextTemplate = nextHoverInfo === 'skip' ? '' : DEFAULT_HOVER_TEMPLATE
@@ -259,7 +263,7 @@ const applyLargeSeriesMode = async (visiblePoints: number) => {
       hoverinfo: nextHoverInfo,
       hovertemplate: nextTemplate,
     })
-    isLargeSeriesMode.value = shouldEnable
+    isLargeSeriesMode.value = hideMarkers
     currentHoverInfo.value = nextHoverInfo
     lastStyledTraceCount.value = traceCount
   }
@@ -296,6 +300,30 @@ const applyLargeSeriesModeForCurrentRange = () => {
     applyLargeSeriesMode(totalPoints)
   }
 }
+
+// Debounced so it runs only AFTER a zoom/pan gesture settles — reconciling
+// (restyle/relayout) mid-gesture makes the zoom jitter and snap back.
+const debouncedPopupRelayout = debounce((eventData: any) => {
+  if (!eventData) return
+  let eventRangeStart = eventData['xaxis.range[0]']
+  let eventRangeEnd = eventData['xaxis.range[1]']
+  const eventRange = eventData['xaxis.range']
+  if (
+    (eventRangeStart === undefined || eventRangeEnd === undefined) &&
+    Array.isArray(eventRange)
+  ) {
+    ;[eventRangeStart, eventRangeEnd] = eventRange
+  }
+  if (eventRangeStart === undefined || eventRangeEnd === undefined) return
+  const rangeStart =
+    typeof eventRangeStart === 'string'
+      ? Date.parse(eventRangeStart)
+      : eventRangeStart
+  const rangeEnd =
+    typeof eventRangeEnd === 'string' ? Date.parse(eventRangeEnd) : eventRangeEnd
+  if (!Number.isFinite(rangeStart) || !Number.isFinite(rangeEnd)) return
+  applyLargeSeriesMode(getVisiblePointCount(rangeStart, rangeEnd))
+}, 400)
 
 const dateOptions = [
   {
@@ -450,30 +478,10 @@ const renderPlot = async () => {
     if (!handlersAttached) {
       const plot = plotlyRef.value
       if (!plot) return
-      plot.on('plotly_relayout', (eventData: any) => {
-        if (!eventData) return
-        let eventRangeStart = eventData['xaxis.range[0]']
-        let eventRangeEnd = eventData['xaxis.range[1]']
-        const eventRange = eventData['xaxis.range']
-        if (
-          (eventRangeStart === undefined || eventRangeEnd === undefined) &&
-          Array.isArray(eventRange)
-        ) {
-          ;[eventRangeStart, eventRangeEnd] = eventRange
-        }
-        if (eventRangeStart === undefined || eventRangeEnd === undefined) return
-        const rangeStart =
-          typeof eventRangeStart === 'string'
-            ? Date.parse(eventRangeStart)
-            : eventRangeStart
-        const rangeEnd =
-          typeof eventRangeEnd === 'string'
-            ? Date.parse(eventRangeEnd)
-            : eventRangeEnd
-        if (!Number.isFinite(rangeStart) || !Number.isFinite(rangeEnd)) return
-        applyLargeSeriesMode(getVisiblePointCount(rangeStart, rangeEnd))
-      })
-      plot.on('plotly_afterplot', applyLargeSeriesModeForCurrentRange)
+      // No `plotly_afterplot` hook: it fires every frame during a drag/zoom and
+      // reconciling there mutates the plot mid-gesture (jitter + snap-back).
+      // The debounced relayout handler + the post-render call below cover it.
+      plot.on('plotly_relayout', debouncedPopupRelayout)
       handlersAttached = true
     }
   } else {

--- a/apps/data-management/src/components/VisualizeData/DataVisualizationCard.vue
+++ b/apps/data-management/src/components/VisualizeData/DataVisualizationCard.vue
@@ -204,11 +204,14 @@ const LARGE_SERIES_TOTAL_THRESHOLD = 150_000
 const DEFAULT_HOVER_TEMPLATE = '<b>%{y}</b><extra></extra>'
 const currentHoverInfo = ref<'y' | 'skip'>('y')
 const isLargeSeriesMode = ref(false)
+const isHoverDisabled = ref(false)
 const defaultTraceModes = ref<string[]>([])
 const defaultMarkerSizes = ref<number[]>([])
 const defaultHoverMode = ref<'x' | false>('x')
 const lastStyledTraceCount = ref(0)
-const showLargeSeriesDisclaimer = computed(() => isLargeSeriesMode.value)
+const showLargeSeriesDisclaimer = computed(
+  () => isLargeSeriesMode.value || isHoverDisabled.value
+)
 const largeSeriesVisibleThreshold = computed(() =>
   LARGE_SERIES_VISIBLE_THRESHOLD.toLocaleString()
 )
@@ -297,33 +300,40 @@ const normalizeTraceArray = <T>(values: T[], length: number, fallback: T) => {
 const applyLargeSeriesMode = async (visiblePoints: number) => {
   if (!plotlyRef.value || !plotlyApi) return
   const totalPoints = getTotalPointCount()
+  // Markers are a viewport concern: hide them only when the *visible* window is
+  // too dense to draw meaningfully. scattergl renders markers on the GPU, so
+  // zooming into a sparse window restores them even on a huge series. This is
+  // how points reappear for datasets whose line is broken by intended-spacing
+  // gaps (the "large dataset shows nothing" case) — previously markers were
+  // force-disabled by total count at every zoom level.
+  const hideMarkers = visiblePoints > LARGE_SERIES_VISIBLE_THRESHOLD
+  // Hover (nearest-point search) is the genuinely total-sensitive cost, so keep
+  // it gated on the total point count.
   const forceLargeMode = totalPoints > LARGE_SERIES_TOTAL_THRESHOLD
-  const shouldEnable =
-    visiblePoints > LARGE_SERIES_VISIBLE_THRESHOLD || forceLargeMode
 
   const traceCount = plotlyRef.value.data?.length ?? 0
   if (!traceCount) return
   const needsEnforcement =
-    shouldEnable &&
+    hideMarkers &&
     plotlyRef.value.data?.some((trace: any) => {
       if (trace?.mode !== 'lines') return true
       const size = trace?.marker?.size
       return typeof size === 'number' ? size !== 0 : false
     })
-  const nextModes = shouldEnable
+  const nextModes = hideMarkers
     ? new Array(traceCount).fill('lines')
     : normalizeTraceArray(defaultTraceModes.value, traceCount, 'lines+markers')
-  const nextMarkerSizes = shouldEnable
+  const nextMarkerSizes = hideMarkers
     ? new Array(traceCount).fill(0)
     : normalizeTraceArray(defaultMarkerSizes.value, traceCount, 6)
-  const nextHoverInfo: 'y' | 'skip' = shouldEnable ? 'skip' : 'y'
+  const nextHoverInfo: 'y' | 'skip' = hideMarkers ? 'skip' : 'y'
   const nextHoverMode = forceLargeMode ? false : defaultHoverMode.value
   const traceCountChanged = traceCount !== lastStyledTraceCount.value
 
   if (
     traceCountChanged ||
     needsEnforcement ||
-    shouldEnable !== isLargeSeriesMode.value ||
+    hideMarkers !== isLargeSeriesMode.value ||
     nextHoverInfo !== currentHoverInfo.value
   ) {
     const nextTemplate = nextHoverInfo === 'skip' ? '' : DEFAULT_HOVER_TEMPLATE
@@ -333,10 +343,12 @@ const applyLargeSeriesMode = async (visiblePoints: number) => {
       hoverinfo: nextHoverInfo,
       hovertemplate: nextTemplate,
     })
-    isLargeSeriesMode.value = shouldEnable
+    isLargeSeriesMode.value = hideMarkers
     currentHoverInfo.value = nextHoverInfo
     lastStyledTraceCount.value = traceCount
   }
+
+  isHoverDisabled.value = forceLargeMode
 
   if (
     plotlyRef.value &&
@@ -629,12 +641,18 @@ const handleRelayout = async (eventData: any) => {
   if (rangeMatchesCurrent) xAxisRange.value = null
 }
 
-const debouncedRelayout = debounce(handleRelayout, 450)
+// Debounced so it runs only AFTER a zoom/pan gesture settles. Reconciling
+// (which issues restyle/relayout) mid-gesture interrupts Plotly's interaction
+// and makes zoom jitter and snap back, so keep this window comfortably long.
+const debouncedRelayout = debounce(handleRelayout, 400)
 
 const attachHandlers = () => {
   if (!plotlyRef.value || handlersAttached.value) return
+  // NB: we deliberately do NOT hook `plotly_afterplot`. It fires on every frame
+  // during a drag/zoom, and reconciling there mutates the plot mid-gesture,
+  // which fought the zoom (jitter + snap-back). Marker/hover reconciliation runs
+  // on render (below) and after the debounced relayout instead.
   plotlyRef.value.on('plotly_relayout', debouncedRelayout)
-  plotlyRef.value.on('plotly_afterplot', applyLargeSeriesModeForCurrentRange)
   handlersAttached.value = true
 }
 

--- a/apps/data-management/src/components/VisualizeData/DataVisualizationCard.vue
+++ b/apps/data-management/src/components/VisualizeData/DataVisualizationCard.vue
@@ -81,10 +81,11 @@
                         </v-card-title>
                         <v-divider />
                         <v-card-text class="px-4 py-2 text-body-2">
-                          Tooltips and markers are disabled to keep the plot
-                          responsive. This happens when visible points exceed
-                          {{ largeSeriesVisibleThreshold }} or total points
-                          exceed {{ largeSeriesTotalThreshold }}.
+                          Tooltips are disabled when total points exceed
+                          {{ largeSeriesTotalThreshold }}. Markers are hidden
+                          when visible points exceed
+                          {{ largeSeriesVisibleThreshold }}. Zoom in below the
+                          marker limit to show them again.
                         </v-card-text>
                       </v-card>
                     </v-tooltip>
@@ -149,7 +150,7 @@ import { useDataVisStore } from '@/store/dataVisualization'
 import { ref, watch, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { storeToRefs } from 'pinia'
 import { debounce } from 'lodash-es'
-import { getXRangeBounds } from '@/utils/plotting/plotly'
+import { getXRangeBounds, supportsWebgl } from '@/utils/plotting/plotly'
 import { mdiChartLine, mdiSigma } from '@mdi/js'
 
 const emit = defineEmits(['copy-state'])
@@ -199,7 +200,11 @@ const parseDateAxisValue = (value: unknown) => {
   return null
 }
 
-const LARGE_SERIES_VISIBLE_THRESHOLD = 50_000
+// scattergl (WebGL) draws markers on the GPU and stays usable into the
+// hundreds of thousands of visible points, so we push close to that bound.
+// Without WebGL, Plotly falls back to SVG markers, which choke at a few
+// thousand — so cap far lower in that case.
+const LARGE_SERIES_VISIBLE_THRESHOLD = supportsWebgl() ? 200_000 : 5_000
 const LARGE_SERIES_TOTAL_THRESHOLD = 150_000
 const DEFAULT_HOVER_TEMPLATE = '<b>%{y}</b><extra></extra>'
 const currentHoverInfo = ref<'y' | 'skip'>('y')

--- a/apps/data-management/src/components/VisualizeData/DataVisualizationCard.vue
+++ b/apps/data-management/src/components/VisualizeData/DataVisualizationCard.vue
@@ -538,7 +538,7 @@ const handleRelayout = async (eventData: any) => {
   const normalizeAxisKey = (key: string) => (key === 'yaxis1' ? 'yaxis' : key)
 
   eventKeys.forEach((key) => {
-    const autorangeMatch = key.match(/^(yaxis\\d*)\\.autorange$/)
+    const autorangeMatch = key.match(/^(yaxis\d*)\.autorange$/)
     if (autorangeMatch && eventData[key] === true) {
       if (!isResizeEvent) {
         delete nextYRanges[normalizeAxisKey(autorangeMatch[1])]
@@ -547,7 +547,7 @@ const handleRelayout = async (eventData: any) => {
       return
     }
 
-    const rangeArrayMatch = key.match(/^(yaxis\\d*)\\.range$/)
+    const rangeArrayMatch = key.match(/^(yaxis\d*)\.range$/)
     if (rangeArrayMatch && Array.isArray(eventData[key])) {
       const [start, end] = eventData[key]
       const parsedStart = parseNumericAxisValue(start)
@@ -562,7 +562,7 @@ const handleRelayout = async (eventData: any) => {
       return
     }
 
-    const rangeMatch = key.match(/^(yaxis\\d*)\\.range\\[(0|1)\\]$/)
+    const rangeMatch = key.match(/^(yaxis\d*)\.range\[(0|1)\]$/)
     if (!rangeMatch) return
     const axisKey = normalizeAxisKey(rangeMatch[1])
     const index = Number(rangeMatch[2])

--- a/apps/data-management/src/components/VisualizeData/DataVisualizationCard.vue
+++ b/apps/data-management/src/components/VisualizeData/DataVisualizationCard.vue
@@ -398,7 +398,7 @@ const captureAxisRangesFromPlotly = () => {
   if (Array.isArray(xRange) && xRange.length === 2) {
     const start = parseDateAxisValue(xRange[0])
     const end = parseDateAxisValue(xRange[1])
-    if (start !== null && end !== null) {
+    if (start !== null && end !== null && start < end) {
       xAxisRange.value = { start, end }
     }
   }
@@ -616,6 +616,7 @@ const handleRelayout = async (eventData: any) => {
       ? Date.parse(eventRangeEnd)
       : eventRangeEnd
   if (!Number.isFinite(rangeStart) || !Number.isFinite(rangeEnd)) return
+  if (rangeStart >= rangeEnd) return
 
   const bounds =
     plotlyOptions.value?.xRange || getXRangeBounds(graphSeriesArray.value)

--- a/apps/data-management/src/components/VisualizeData/DataVisualizationCard.vue
+++ b/apps/data-management/src/components/VisualizeData/DataVisualizationCard.vue
@@ -399,7 +399,9 @@ const captureAxisRangesFromPlotly = () => {
     const start = parseDateAxisValue(xRange[0])
     const end = parseDateAxisValue(xRange[1])
     if (start !== null && end !== null && start < end) {
-      xAxisRange.value = { start, end }
+      xAxisRange.value = isImplicitXAxisRange(start, end)
+        ? null
+        : { start, end }
     }
   }
 
@@ -500,6 +502,34 @@ const RANGE_MATCH_TOLERANCE_MS = 5 * 60 * 1000
 
 const isWithinTolerance = (value: number, target: number, tolerance: number) =>
   Math.abs(value - target) <= tolerance
+
+const rangeMatchesCurrentDateRange = (rangeStart: number, rangeEnd: number) => {
+  const currentStart = beginDate.value?.getTime()
+  const currentEnd = endDate.value?.getTime()
+  return (
+    currentStart !== undefined &&
+    currentEnd !== undefined &&
+    isWithinTolerance(rangeStart, currentStart, RANGE_MATCH_TOLERANCE_MS) &&
+    isWithinTolerance(rangeEnd, currentEnd, RANGE_MATCH_TOLERANCE_MS)
+  )
+}
+
+const rangeMatchesFullDataView = (rangeStart: number, rangeEnd: number) => {
+  if (dataZoomStart.value !== 0 || dataZoomEnd.value !== 100) return false
+
+  const bounds =
+    plotlyOptions.value?.xRange || getXRangeBounds(graphSeriesArray.value)
+  if (!bounds) return false
+
+  return (
+    isWithinTolerance(rangeStart, bounds.min, RANGE_MATCH_TOLERANCE_MS) &&
+    isWithinTolerance(rangeEnd, bounds.max, RANGE_MATCH_TOLERANCE_MS)
+  )
+}
+
+const isImplicitXAxisRange = (rangeStart: number, rangeEnd: number) =>
+  rangeMatchesFullDataView(rangeStart, rangeEnd) ||
+  rangeMatchesCurrentDateRange(rangeStart, rangeEnd)
 
 const preserveLiveAxisRanges = () => {
   if (!plotlyRef.value || !plotlyOptions.value) return
@@ -631,20 +661,12 @@ const handleRelayout = async (eventData: any) => {
   dataZoomEnd.value = Math.round(
     clampPercent(((rangeEnd - bounds.min) / span) * 100)
   )
-  xAxisRange.value = { start: rangeStart, end: rangeEnd }
+  xAxisRange.value = isImplicitXAxisRange(rangeStart, rangeEnd)
+    ? null
+    : { start: rangeStart, end: rangeEnd }
 
   const visiblePoints = getVisiblePointCount(rangeStart, rangeEnd)
   await applyLargeSeriesMode(visiblePoints)
-
-  const currentStart = beginDate.value?.getTime()
-  const currentEnd = endDate.value?.getTime()
-  const rangeMatchesCurrent =
-    currentStart !== undefined &&
-    currentEnd !== undefined &&
-    isWithinTolerance(rangeStart, currentStart, RANGE_MATCH_TOLERANCE_MS) &&
-    isWithinTolerance(rangeEnd, currentEnd, RANGE_MATCH_TOLERANCE_MS)
-
-  if (rangeMatchesCurrent) xAxisRange.value = null
 }
 
 // Debounced so it runs only AFTER a zoom/pan gesture settles. Reconciling

--- a/apps/data-management/src/pages/VisualizeData.vue
+++ b/apps/data-management/src/pages/VisualizeData.vue
@@ -142,8 +142,7 @@ const generateStateUrl = () => {
   if (dataZoomEnd.value !== 0 && dataZoomEnd.value !== 100)
     queryParams.append('dataZoomEnd', dataZoomEnd.value.toString())
 
-  // Preset ranges must remain relative when the copied URL is reopened.
-  if (selectedDateBtnId.value < 0 && xAxisRange.value) {
+  if (xAxisRange.value) {
     queryParams.append('xStart', xAxisRange.value.start.toString())
     queryParams.append('xEnd', xAxisRange.value.end.toString())
   }
@@ -292,11 +291,7 @@ const parseUrlAndSetState = () => {
   const xEndRaw = Array.isArray(xEndParam) ? xEndParam[0] : xEndParam
   const xStart = xStartRaw ? Number(xStartRaw) : null
   const xEnd = xEndRaw ? Number(xEndRaw) : null
-  if (
-    selectedDateBtnId.value < 0 &&
-    Number.isFinite(xStart) &&
-    Number.isFinite(xEnd)
-  ) {
+  if (Number.isFinite(xStart) && Number.isFinite(xEnd)) {
     xAxisRange.value = { start: xStart as number, end: xEnd as number }
   } else {
     xAxisRange.value = null

--- a/apps/data-management/src/pages/VisualizeData.vue
+++ b/apps/data-management/src/pages/VisualizeData.vue
@@ -106,6 +106,16 @@ const handleDrawerChange = () => {
   }, 250)
 }
 
+const isValidAxisRange = (
+  range: { start: number; end: number } | null
+): range is { start: number; end: number } =>
+  Boolean(
+    range &&
+      Number.isFinite(range.start) &&
+      Number.isFinite(range.end) &&
+      range.start < range.end
+  )
+
 const generateStateUrl = () => {
   const BASE_URL = new URL('/visualize-data', window.location.origin).toString()
 
@@ -142,7 +152,7 @@ const generateStateUrl = () => {
   if (dataZoomEnd.value !== 0 && dataZoomEnd.value !== 100)
     queryParams.append('dataZoomEnd', dataZoomEnd.value.toString())
 
-  if (xAxisRange.value) {
+  if (isValidAxisRange(xAxisRange.value)) {
     queryParams.append('xStart', xAxisRange.value.start.toString())
     queryParams.append('xEnd', xAxisRange.value.end.toString())
   }
@@ -291,7 +301,11 @@ const parseUrlAndSetState = () => {
   const xEndRaw = Array.isArray(xEndParam) ? xEndParam[0] : xEndParam
   const xStart = xStartRaw ? Number(xStartRaw) : null
   const xEnd = xEndRaw ? Number(xEndRaw) : null
-  if (Number.isFinite(xStart) && Number.isFinite(xEnd)) {
+  if (
+    Number.isFinite(xStart) &&
+    Number.isFinite(xEnd) &&
+    (xStart as number) < (xEnd as number)
+  ) {
     xAxisRange.value = { start: xStart as number, end: xEnd as number }
   } else {
     xAxisRange.value = null

--- a/apps/data-management/src/utils/plotting/plotly.ts
+++ b/apps/data-management/src/utils/plotting/plotly.ts
@@ -381,7 +381,9 @@ export const createPlotlyOption = (
   const titleColor = seriesArray[0]?.lineColor
 
   const layout: any = {
-    margin: { l: 4, r: 0, t: legendTopMargin, b: 70, pad: 0 },
+    // `b` is fixed (x-axis automargin is off — see xaxis below) so it must hold
+    // the worst case: two-line date tick labels + the "Datetime" title.
+    margin: { l: 4, r: 0, t: legendTopMargin, b: 80, pad: 0 },
     showlegend: addLegend,
     legend: addLegend
       ? {
@@ -402,7 +404,12 @@ export const createPlotlyOption = (
       gridwidth: 1,
       domain: [xDomainStart, xDomainEnd],
       title: { text: 'Datetime', standoff: 24 },
-      automargin: true,
+      // `automargin` must stay OFF on this date axis: zooming X changes the tick
+      // label format (1-line <-> 2-line dates), and with automargin on, Plotly
+      // recomputes the bottom margin every zoom step, making the plot area jump
+      // (X-axis zoom jitter). The fixed `margin.b` below already reserves enough
+      // room for the labels + "Datetime" title, so pinning this keeps X smooth.
+      automargin: false,
       range:
         resolvedRangeStart !== undefined && resolvedRangeEnd !== undefined
           ? [resolvedRangeStart, resolvedRangeEnd]

--- a/apps/data-management/src/utils/plotting/plotly.ts
+++ b/apps/data-management/src/utils/plotting/plotly.ts
@@ -77,7 +77,7 @@ const rangeSelectorOptions = {
   ],
 }
 
-const supportsWebgl = () => {
+export const supportsWebgl = () => {
   if (cachedWebglSupport !== null) return cachedWebglSupport
   if (typeof document === 'undefined' || typeof window === 'undefined') {
     cachedWebglSupport = false


### PR DESCRIPTION
Resolves #415 

I solved by increasing the rate limit for markers to 200_000 instead of 50_000 on computers that have GPUs - and I made it so that limit only counts for the active-view datapoints. Zooming in will restore the markers once we're under the 200_000 data point limit. The tooltips still get disabled at 150_000 data points. I made a note of this in the 'large data mode' help text the user sees after they've hit the max limit. Of course, for datasets where the user has an intended time spacing that matches their data frequency, the line will connect points so having no markers won't be a problem. But for this edge case, the rate increase will prevent this from happening for most datasets.

I also fixed two bugs with the plot: 
1. zooming the X axis from inside the plot triggered refreshes making the plot jitter when zooming
2. The x axis zoom level wasn't getting saved when the user used 'copy state as URL'  