### PR TITLE
508 scroll

### DIFF
--- a/apps/data-management/e2e/specs/metadata.spec.ts
+++ b/apps/data-management/e2e/specs/metadata.spec.ts
@@ -71,6 +71,39 @@ test.describe('metadata management', () => {
     await expect(page.getByTestId('workspace-metadata-table')).toHaveCount(0)
   })
 
+  test('admins can update and delete system metadata from the all metadata table', async ({
+    page,
+  }) => {
+    const qualifier = fixtures.metadata.editableSystemResultQualifier
+    const renamedCode = `${qualifier.name}-UPDATED`
+
+    await authenticateSession(page, users.admin.email, users.admin.password)
+    await page.goto(
+      `/workspaces?workspace=${fixtures.workspaces.admin.id}&section=metadata`
+    )
+
+    await page.getByRole('button', { name: 'All', exact: true }).click()
+    await page.getByRole('tab', { name: 'Result qualifiers' }).click()
+
+    const allTable = page.getByTestId('all-metadata-table')
+    const editButton = allTable.getByTestId(`edit-metadata-${qualifier.id}`)
+    const deleteButton = allTable.getByTestId(`delete-metadata-${qualifier.id}`)
+    await expect(editButton).toBeVisible()
+    await expect(deleteButton).toBeVisible()
+
+    await editButton.click()
+    await page.getByLabel('Code *').fill(renamedCode)
+    await page.getByRole('button', { name: 'Update', exact: true }).click()
+
+    const renamedRow = allTable.locator('tr').filter({ hasText: renamedCode })
+    await expect(renamedRow).toBeVisible()
+
+    await renamedRow.getByLabel('Delete metadata item').click()
+    await expect(page.getByText(/isn't being used|not.*used/i)).toBeVisible()
+    await page.getByRole('button', { name: 'Delete', exact: true }).click()
+    await expect(renamedRow).toHaveCount(0)
+  })
+
   test('workspace method metadata can be created, updated, and deleted', async ({
     page,
   }) => {

--- a/apps/data-management/e2e/specs/metadata.spec.ts
+++ b/apps/data-management/e2e/specs/metadata.spec.ts
@@ -86,6 +86,9 @@ test.describe('metadata management', () => {
     await page.getByRole('tab', { name: 'Result qualifiers' }).click()
 
     const allTable = page.getByTestId('all-metadata-table')
+    await allTable
+      .getByRole('textbox', { name: 'Search metadata' })
+      .fill(qualifier.name)
     const editButton = allTable.getByTestId(`edit-metadata-${qualifier.id}`)
     const deleteButton = allTable.getByTestId(`delete-metadata-${qualifier.id}`)
     await expect(editButton).toBeVisible()

--- a/apps/data-management/e2e/specs/workspaces.spec.ts
+++ b/apps/data-management/e2e/specs/workspaces.spec.ts
@@ -112,9 +112,9 @@ test.describe('workspace management', () => {
 
     await page.getByRole('tab', { name: 'Overview' }).click()
     await expect(page.getByTestId('overview-members-count')).toHaveText('3')
-    await expect(page.getByTestId('overview-service-accounts-count')).toHaveText(
-      '1'
-    )
+    await expect(
+      page.getByTestId('overview-service-accounts-count')
+    ).toHaveText('1')
 
     await page.getByRole('tab', { name: 'Collaborators' }).click()
     await expect(
@@ -169,6 +169,80 @@ test.describe('workspace management', () => {
         exact: false,
       })
     ).toHaveCount(0)
+  })
+
+  test('service account and metadata tables fit the remaining viewport height', async ({
+    page,
+  }) => {
+    const readTableLayout = async (sectionTestId: string) =>
+      page.getByTestId(sectionTestId).evaluate((section) => {
+        const detailBody = section.closest('.detail-body') as HTMLElement | null
+        const table = section.querySelector(
+          '.v-data-table'
+        ) as HTMLElement | null
+        const wrapper = table?.querySelector(
+          '.v-table__wrapper'
+        ) as HTMLElement | null
+
+        if (!detailBody || !table || !wrapper)
+          throw new Error('Unable to measure the workspace table layout.')
+
+        const detailRect = detailBody.getBoundingClientRect()
+        const tableRect = table.getBoundingClientRect()
+
+        return {
+          detailOverflowY: getComputedStyle(detailBody).overflowY,
+          detailScrollOverflow:
+            detailBody.scrollHeight - detailBody.clientHeight,
+          tableHeight: tableRect.height,
+          tableBottomGap: detailRect.bottom - tableRect.bottom,
+          tableOverflowY: getComputedStyle(wrapper).overflowY,
+        }
+      })
+
+    const expectFittedTable = (
+      layout: Awaited<ReturnType<typeof readTableLayout>>
+    ) => {
+      expect(layout.detailOverflowY).toBe('hidden')
+      expect(layout.detailScrollOverflow).toBeLessThanOrEqual(1)
+      expect(layout.tableBottomGap).toBeGreaterThanOrEqual(14)
+      expect(layout.tableBottomGap).toBeLessThanOrEqual(18)
+      expect(layout.tableOverflowY).toBe('auto')
+    }
+
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await authenticateSession(page, users.owner.email, users.owner.password)
+    await page.goto(
+      `/workspaces?workspace=${fixtures.workspaces.public.id}&section=service-accounts`
+    )
+    await expect(page.getByTestId('service-accounts-section')).toBeVisible()
+
+    const tallServiceAccounts = await readTableLayout(
+      'service-accounts-section'
+    )
+    expectFittedTable(tallServiceAccounts)
+
+    await page.setViewportSize({ width: 1280, height: 600 })
+    const shortServiceAccounts = await readTableLayout(
+      'service-accounts-section'
+    )
+    expectFittedTable(shortServiceAccounts)
+    expect(shortServiceAccounts.tableHeight).toBeLessThan(
+      tallServiceAccounts.tableHeight
+    )
+
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await page.getByRole('tab', { name: 'Metadata' }).click()
+    await expect(page.getByTestId('workspace-metadata-table')).toBeVisible()
+    await expect(page.getByTestId('service-accounts-section')).toBeHidden()
+
+    const tallMetadata = await readTableLayout('workspace-metadata-table')
+    expectFittedTable(tallMetadata)
+
+    await page.setViewportSize({ width: 1280, height: 600 })
+    const shortMetadata = await readTableLayout('workspace-metadata-table')
+    expectFittedTable(shortMetadata)
+    expect(shortMetadata.tableHeight).toBeLessThan(tallMetadata.tableHeight)
   })
 
   test('viewer sees read-only workspace management controls', async ({

--- a/apps/data-management/e2e/specs/workspaces.spec.ts
+++ b/apps/data-management/e2e/specs/workspaces.spec.ts
@@ -200,14 +200,31 @@ test.describe('workspace management', () => {
         }
       })
 
-    const expectFittedTable = (
-      layout: Awaited<ReturnType<typeof readTableLayout>>
-    ) => {
+    const expectFittedTable = async (sectionTestId: string) => {
+      // Vuetify's window transition can make the newly selected table visible
+      // before its flex layout has reached its final height. Poll the complete
+      // layout contract so measurements describe the settled tab, not an
+      // intermediate animation frame.
+      await expect
+        .poll(async () => {
+          const layout = await readTableLayout(sectionTestId)
+          return (
+            layout.detailOverflowY === 'hidden' &&
+            layout.detailScrollOverflow <= 1 &&
+            layout.tableBottomGap >= 14 &&
+            layout.tableBottomGap <= 18 &&
+            layout.tableOverflowY === 'auto'
+          )
+        })
+        .toBe(true)
+
+      const layout = await readTableLayout(sectionTestId)
       expect(layout.detailOverflowY).toBe('hidden')
       expect(layout.detailScrollOverflow).toBeLessThanOrEqual(1)
       expect(layout.tableBottomGap).toBeGreaterThanOrEqual(14)
       expect(layout.tableBottomGap).toBeLessThanOrEqual(18)
       expect(layout.tableOverflowY).toBe('auto')
+      return layout
     }
 
     await page.setViewportSize({ width: 1280, height: 720 })
@@ -217,16 +234,14 @@ test.describe('workspace management', () => {
     )
     await expect(page.getByTestId('service-accounts-section')).toBeVisible()
 
-    const tallServiceAccounts = await readTableLayout(
+    const tallServiceAccounts = await expectFittedTable(
       'service-accounts-section'
     )
-    expectFittedTable(tallServiceAccounts)
 
     await page.setViewportSize({ width: 1280, height: 600 })
-    const shortServiceAccounts = await readTableLayout(
+    const shortServiceAccounts = await expectFittedTable(
       'service-accounts-section'
     )
-    expectFittedTable(shortServiceAccounts)
     expect(shortServiceAccounts.tableHeight).toBeLessThan(
       tallServiceAccounts.tableHeight
     )
@@ -236,12 +251,10 @@ test.describe('workspace management', () => {
     await expect(page.getByTestId('workspace-metadata-table')).toBeVisible()
     await expect(page.getByTestId('service-accounts-section')).toBeHidden()
 
-    const tallMetadata = await readTableLayout('workspace-metadata-table')
-    expectFittedTable(tallMetadata)
+    const tallMetadata = await expectFittedTable('workspace-metadata-table')
 
     await page.setViewportSize({ width: 1280, height: 600 })
-    const shortMetadata = await readTableLayout('workspace-metadata-table')
-    expectFittedTable(shortMetadata)
+    const shortMetadata = await expectFittedTable('workspace-metadata-table')
     expect(shortMetadata.tableHeight).toBeLessThan(tallMetadata.tableHeight)
   })
 

--- a/apps/data-management/e2e/specs/workspaces.spec.ts
+++ b/apps/data-management/e2e/specs/workspaces.spec.ts
@@ -110,6 +110,24 @@ test.describe('workspace management', () => {
       `/workspaces?workspace=${fixtures.workspaces.public.id}&section=service-accounts`
     )
 
+    await page.getByRole('tab', { name: 'Overview' }).click()
+    await expect(page.getByTestId('overview-members-count')).toHaveText('3')
+    await expect(page.getByTestId('overview-service-accounts-count')).toHaveText(
+      '1'
+    )
+
+    await page.getByRole('tab', { name: 'Collaborators' }).click()
+    await expect(
+      page.getByTestId(`collaborator-row-${users.owner.email}`)
+    ).toBeVisible()
+    await expect(
+      page.locator('.collaborator-table').getByText('apikey', { exact: true })
+    ).toHaveCount(0)
+    await page.getByRole('tab', { name: 'Service accounts' }).click()
+    await expect(
+      page.getByRole('row', { name: /apikey Data Loader/ })
+    ).toBeVisible()
+
     await page.getByRole('button', { name: 'Create service account' }).click()
     let dialog = page.getByRole('dialog')
     await dialog.getByLabel('Name *').fill(keyName)

--- a/apps/data-management/e2e/support/fixtures.ts
+++ b/apps/data-management/e2e/support/fixtures.ts
@@ -1,6 +1,10 @@
 export const E2E_PASSWORD = 'HydroServer123!'
 
 export let users = {
+  admin: {
+    email: 'admin@uninitialized.invalid',
+    password: E2E_PASSWORD,
+  },
   owner: {
     email: 'owner@uninitialized.invalid',
     password: E2E_PASSWORD,
@@ -33,6 +37,10 @@ export let users = {
 
 export let fixtures = {
   workspaces: {
+    admin: {
+      id: 'uninitialized',
+      name: 'Admin',
+    },
     public: {
       id: 'uninitialized',
       name: 'Public',
@@ -115,6 +123,10 @@ export let fixtures = {
     systemMethod: {
       id: 'uninitialized',
       name: 'System Method',
+    },
+    editableSystemResultQualifier: {
+      id: 'uninitialized',
+      name: 'Editable System Result Qualifier',
     },
   },
   orchestration: {

--- a/apps/data-management/src/components/Datastream/DatastreamTable.vue
+++ b/apps/data-management/src/components/Datastream/DatastreamTable.vue
@@ -48,13 +48,14 @@
 
     <div v-if="isMobile" class="datastream-mobile-list">
       <v-card
-        v-for="item in tableDatastreams"
+        v-for="(item, index) in renderedDatastreams"
         :key="item.id"
         class="datastream-card"
         :class="{
           'datastream-card--highlighted': isTargetDatastream(item.id),
         }"
         :data-datastream-id="item.id"
+        :data-load-more-trigger="isLoadMoreTrigger(index) ? 'true' : undefined"
         variant="outlined"
       >
         <div class="datastream-card__content">
@@ -168,8 +169,8 @@
                 !linkedTasksForDatastream(item.id).length
                   ? mdiLinkOff
                   : linkedTasksForDatastream(item.id).length > 1
-                  ? mdiAlertOctagon
-                  : linkedTasksForDatastream(item.id)[0].icon
+                    ? mdiAlertOctagon
+                    : linkedTasksForDatastream(item.id)[0].icon
               "
               size="20"
             />
@@ -180,8 +181,8 @@
                     linkedTasksForDatastream(item.id).length > 1
                       ? 'Multiple task targets'
                       : linkedTasksForDatastream(item.id).length === 1
-                      ? linkedTasksForDatastream(item.id)[0].label
-                      : 'No task connected'
+                        ? linkedTasksForDatastream(item.id)[0].label
+                        : 'No task connected'
                   }}
                 </span>
                 <template v-if="linkedTasksForDatastream(item.id).length === 1">
@@ -467,7 +468,10 @@
                   :data-testid="`visualize-datastream-${item.id}`"
                   :to="{
                     name: 'VisualizeData',
-                    query: { sites: item.monitoringSiteId, datastreams: item.id },
+                    query: {
+                      sites: item.monitoringSiteId,
+                      datastreams: item.id,
+                    },
                   }"
                 />
                 <v-list-item
@@ -515,11 +519,12 @@
       </div>
 
       <div
-        v-for="item in tableDatastreams"
+        v-for="(item, index) in renderedDatastreams"
         :key="item.id"
         class="ds-card"
         :class="{ 'ds-card--highlighted': isTargetDatastream(item.id) }"
         :data-datastream-id="item.id"
+        :data-load-more-trigger="isLoadMoreTrigger(index) ? 'true' : undefined"
       >
         <div class="ds-card__grid">
           <div class="datastream-latest">
@@ -774,7 +779,10 @@
                     :data-testid="`visualize-datastream-${item.id}`"
                     :to="{
                       name: 'VisualizeData',
-                      query: { sites: item.monitoringSiteId, datastreams: item.id },
+                      query: {
+                        sites: item.monitoringSiteId,
+                        datastreams: item.id,
+                      },
                     }"
                   />
                   <v-list-item
@@ -829,8 +837,8 @@
               !linkedTasksForDatastream(item.id).length
                 ? mdiLinkOff
                 : linkedTasksForDatastream(item.id).length > 1
-                ? mdiAlertOctagon
-                : linkedTasksForDatastream(item.id)[0].icon
+                  ? mdiAlertOctagon
+                  : linkedTasksForDatastream(item.id)[0].icon
             "
             size="20"
           />
@@ -841,8 +849,8 @@
                   linkedTasksForDatastream(item.id).length > 1
                     ? 'Multiple task targets'
                     : linkedTasksForDatastream(item.id).length === 1
-                    ? linkedTasksForDatastream(item.id)[0].label
-                    : 'No task connected'
+                      ? linkedTasksForDatastream(item.id)[0].label
+                      : 'No task connected'
                 }}
               </span>
               <template v-if="linkedTasksForDatastream(item.id).length === 1">
@@ -1123,7 +1131,11 @@ const search = ref()
 const datastreamSectionRef = ref<any>(null)
 const highlightedDatastreamId = ref('')
 const DATASTREAM_HIGHLIGHT_DURATION_MS = 2500
+const DATASTREAM_RENDER_BATCH_SIZE = 10
+const DATASTREAM_PRELOAD_AHEAD_COUNT = 10
+const renderedDatastreamCount = ref(DATASTREAM_RENDER_BATCH_SIZE)
 let highlightTimeout: number | undefined
+let loadMoreObserver: IntersectionObserver | undefined
 const { smAndDown } = useDisplay()
 const isMobile = computed(() => smAndDown.value)
 
@@ -1182,7 +1194,9 @@ const onCreated = async () => {
 const { item, items, openEdit, openDelete, openDialog, onUpdate, onDelete } =
   useTableLogic(
     async (monitoringSiteId: string) =>
-      await hs.datastreams.listAllItems({ monitoring_site_id: [monitoringSiteId] }),
+      await hs.datastreams.listAllItems({
+        monitoring_site_id: [monitoringSiteId],
+      }),
     hs.datastreams.delete,
     Datastream,
     monitoringSiteIdRef
@@ -1232,7 +1246,9 @@ const latestStatusClass = (datastream: Datastream) => {
 
 const visibleDatastreams = computed(() => {
   const unitsById = new Map(units.value.map((u) => [u.id, u]))
-  const methodsById = new Map(methods.value.map((method) => [method.id, method]))
+  const methodsById = new Map(
+    methods.value.map((method) => [method.id, method])
+  )
   const opsById = new Map(observedProperties.value.map((o) => [o.id, o]))
   const processingLevelsById = new Map(
     processingLevels.value.map((p) => [p.id, p])
@@ -1308,6 +1324,61 @@ const tableDatastreams = computed(() => {
   )
 })
 
+const renderedDatastreams = computed(() =>
+  tableDatastreams.value.slice(0, renderedDatastreamCount.value)
+)
+
+const hasMoreDatastreams = computed(
+  () => renderedDatastreams.value.length < tableDatastreams.value.length
+)
+
+const loadMoreTriggerIndex = computed(() => {
+  if (!hasMoreDatastreams.value) return -1
+  return Math.max(
+    0,
+    renderedDatastreams.value.length - DATASTREAM_PRELOAD_AHEAD_COUNT
+  )
+})
+
+function isLoadMoreTrigger(index: number) {
+  return index === loadMoreTriggerIndex.value
+}
+
+function loadMoreDatastreams() {
+  if (!hasMoreDatastreams.value) return
+  loadMoreObserver?.disconnect()
+  renderedDatastreamCount.value = Math.min(
+    renderedDatastreamCount.value + DATASTREAM_RENDER_BATCH_SIZE,
+    tableDatastreams.value.length
+  )
+}
+
+async function observeLoadMoreTrigger() {
+  await nextTick()
+  loadMoreObserver?.disconnect()
+  if (!hasMoreDatastreams.value) return
+
+  const trigger = datastreamSectionElement()?.querySelector<HTMLElement>(
+    '[data-load-more-trigger="true"]'
+  )
+  if (!trigger) return
+
+  if (!window.IntersectionObserver) {
+    renderedDatastreamCount.value = tableDatastreams.value.length
+    return
+  }
+
+  loadMoreObserver ??= new IntersectionObserver(
+    (entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        loadMoreDatastreams()
+      }
+    },
+    { root: null, threshold: 0 }
+  )
+  loadMoreObserver.observe(trigger)
+}
+
 const deepLinkedDatastreamId = computed(() => props.targetDatastreamId.trim())
 
 const targetDatastreamIndex = computed(() => {
@@ -1361,6 +1432,14 @@ async function scrollToTargetDatastream() {
 
   if (targetDatastreamIndex.value === -1 && normalizedSearch.value) {
     search.value = ''
+    await nextTick()
+  }
+
+  if (targetDatastreamIndex.value >= renderedDatastreamCount.value) {
+    renderedDatastreamCount.value = Math.min(
+      targetDatastreamIndex.value + DATASTREAM_PRELOAD_AHEAD_COUNT + 1,
+      tableDatastreams.value.length
+    )
     await nextTick()
   }
 
@@ -1539,7 +1618,8 @@ const siteScopedRoute = (task: any, name: string, view: string) => {
     workspace_id: props.workspace.id,
     task_id: String(task.id),
   }
-  const siteId = task.monitoringSite?.id ?? task.monitoringSiteId ?? monitoringSite.value?.id
+  const siteId =
+    task.monitoringSite?.id ?? task.monitoringSiteId ?? monitoringSite.value?.id
   if (siteId) query.site_id = String(siteId)
 
   return { name, params: { view }, query }
@@ -1812,8 +1892,32 @@ watch(
   { immediate: true, flush: 'post' }
 )
 
+watch(
+  normalizedSearch,
+  () => {
+    renderedDatastreamCount.value = Math.min(
+      DATASTREAM_RENDER_BATCH_SIZE,
+      tableDatastreams.value.length
+    )
+  },
+  { flush: 'post' }
+)
+
+watch(
+  [renderedDatastreamCount, () => tableDatastreams.value.length, isMobile],
+  () => {
+    renderedDatastreamCount.value = Math.min(
+      Math.max(renderedDatastreamCount.value, DATASTREAM_RENDER_BATCH_SIZE),
+      tableDatastreams.value.length
+    )
+    void observeLoadMoreTrigger()
+  },
+  { immediate: true, flush: 'post' }
+)
+
 onBeforeUnmount(() => {
   if (highlightTimeout) window.clearTimeout(highlightTimeout)
+  loadMoreObserver?.disconnect()
 })
 
 const onDownload = async (datastreamId: string) => {
@@ -1920,8 +2024,7 @@ const loadDatastreams = async () => {
   --datastream-list-inline: calc(0.75rem + 1px + 0.85rem);
   padding: 0 0 0.75rem;
   background: #fafbfc;
-  max-height: 100vh;
-  overflow-y: auto;
+  overflow: visible;
 }
 
 .datastream-list__head {

--- a/apps/data-management/src/components/Metadata/MetadataTable.vue
+++ b/apps/data-management/src/components/Metadata/MetadataTable.vue
@@ -80,6 +80,7 @@
             :workspace-id="workspaceId"
             :can-edit="canEditMetadata"
             :can-delete="canDeleteMetadata"
+            :can-manage-system="canManageSystemMetadata"
             :scope="scope"
           />
         </v-window-item>
@@ -91,6 +92,7 @@
             :workspace-id="workspaceId"
             :can-edit="canEditMetadata"
             :can-delete="canDeleteMetadata"
+            :can-manage-system="canManageSystemMetadata"
             :scope="scope"
           />
         </v-window-item>
@@ -102,6 +104,7 @@
             :workspace-id="workspaceId"
             :can-edit="canEditMetadata"
             :can-delete="canDeleteMetadata"
+            :can-manage-system="canManageSystemMetadata"
             :scope="scope"
           />
         </v-window-item>
@@ -113,6 +116,7 @@
             :workspace-id="workspaceId"
             :can-edit="canEditMetadata"
             :can-delete="canDeleteMetadata"
+            :can-manage-system="canManageSystemMetadata"
             :scope="scope"
           />
         </v-window-item>
@@ -124,6 +128,7 @@
             :workspace-id="workspaceId"
             :can-edit="canEditMetadata"
             :can-delete="canDeleteMetadata"
+            :can-manage-system="canManageSystemMetadata"
             :scope="scope"
           />
         </v-window-item>
@@ -297,6 +302,7 @@ const canEditMetadata = computed(() =>
 const canDeleteMetadata = computed(() =>
   hasMetadataPermission(PermissionAction.Delete)
 )
+const canManageSystemMetadata = computed(() => isAdmin())
 </script>
 
 <style scoped>

--- a/apps/data-management/src/components/Metadata/MetadataTable.vue
+++ b/apps/data-management/src/components/Metadata/MetadataTable.vue
@@ -300,6 +300,13 @@ const canDeleteMetadata = computed(() =>
 </script>
 
 <style scoped>
+.metadata-section {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
 .metadata-header {
   display: flex;
   align-items: center;
@@ -320,7 +327,27 @@ const canDeleteMetadata = computed(() =>
   margin: 0 0 2px;
 }
 .metadata-table-card {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
   margin-top: 6px;
+  overflow: hidden;
+}
+.metadata-window {
+  flex: 1;
+  min-height: 0;
+}
+.metadata-window :deep(.v-window__container),
+.metadata-window :deep(.v-window-item) {
+  height: 100%;
+  min-height: 0;
+}
+.metadata-window :deep(.v-data-table) {
+  height: 100%;
+  max-height: 100%;
+  min-height: 0;
+  overflow: hidden;
 }
 .metadata-search {
   max-width: 260px;

--- a/apps/data-management/src/components/Metadata/MethodTable.vue
+++ b/apps/data-management/src/components/Metadata/MethodTable.vue
@@ -3,7 +3,7 @@
     :headers="headers"
     :items="sortedItems"
     :search="search"
-    :style="{ 'max-height': `400px` }"
+    height="100%"
     fixed-header
   >
     <template v-slot:item.scope="{ item }">

--- a/apps/data-management/src/components/Metadata/MethodTable.vue
+++ b/apps/data-management/src/components/Metadata/MethodTable.vue
@@ -11,14 +11,14 @@
     </template>
     <template v-slot:item.actions="{ item }">
       <v-icon
-        v-if="canEdit && item._scope !== 'system'"
+        v-if="canEdit && (item._scope !== 'system' || canManageSystem)"
         :icon="mdiPencil"
         :data-testid="`edit-metadata-${item.id}`"
         aria-label="Edit metadata item"
         @click="openDialog(item, 'edit')"
       />
       <v-icon
-        v-if="canDelete && item._scope !== 'system'"
+        v-if="canDelete && (item._scope !== 'system' || canManageSystem)"
         :icon="mdiTrashCanOutline"
         :data-testid="`delete-metadata-${item.id}`"
         aria-label="Delete metadata item"
@@ -65,8 +65,9 @@ import { mdiTrashCanOutline, mdiPencil } from '@mdi/js'
 const props = defineProps<{
   search: string | undefined
   workspaceId?: string
-  canEdit: Boolean
-  canDelete: Boolean
+  canEdit: boolean
+  canDelete: boolean
+  canManageSystem?: boolean
   scope?: 'workspace' | 'system' | 'all'
 }>()
 

--- a/apps/data-management/src/components/Metadata/ObservedPropertyTable.vue
+++ b/apps/data-management/src/components/Metadata/ObservedPropertyTable.vue
@@ -11,14 +11,14 @@
     </template>
     <template v-slot:item.actions="{ item }">
       <v-icon
-        v-if="canEdit && item._scope !== 'system'"
+        v-if="canEdit && (item._scope !== 'system' || canManageSystem)"
         :icon="mdiPencil"
         :data-testid="`edit-metadata-${item.id}`"
         aria-label="Edit metadata item"
         @click="openDialog(item, 'edit')"
       />
       <v-icon
-        v-if="canDelete && item._scope !== 'system'"
+        v-if="canDelete && (item._scope !== 'system' || canManageSystem)"
         :icon="mdiTrashCanOutline"
         :data-testid="`delete-metadata-${item.id}`"
         aria-label="Delete metadata item"
@@ -70,8 +70,9 @@ import { mdiTrashCanOutline, mdiPencil } from '@mdi/js'
 const props = defineProps<{
   search: string | undefined
   workspaceId?: string
-  canEdit: Boolean
-  canDelete: Boolean
+  canEdit: boolean
+  canDelete: boolean
+  canManageSystem?: boolean
   scope?: 'workspace' | 'system' | 'all'
 }>()
 

--- a/apps/data-management/src/components/Metadata/ObservedPropertyTable.vue
+++ b/apps/data-management/src/components/Metadata/ObservedPropertyTable.vue
@@ -3,7 +3,7 @@
     :headers="headers"
     :items="sortedItems"
     :search="search"
-    :style="{ 'max-height': `400px` }"
+    height="100%"
     fixed-header
   >
     <template v-slot:item.scope="{ item }">

--- a/apps/data-management/src/components/Metadata/ProcessingLevelTable.vue
+++ b/apps/data-management/src/components/Metadata/ProcessingLevelTable.vue
@@ -3,7 +3,7 @@
     :headers="ProcLevelHeaders"
     :items="sortedItems"
     :search="search"
-    :style="{ 'max-height': `400px` }"
+    height="100%"
     fixed-header
   >
     <template v-slot:item.scope="{ item }">

--- a/apps/data-management/src/components/Metadata/ProcessingLevelTable.vue
+++ b/apps/data-management/src/components/Metadata/ProcessingLevelTable.vue
@@ -11,14 +11,14 @@
     </template>
     <template v-slot:item.actions="{ item }">
       <v-icon
-        v-if="canEdit && item._scope !== 'system'"
+        v-if="canEdit && (item._scope !== 'system' || canManageSystem)"
         :icon="mdiPencil"
         :data-testid="`edit-metadata-${item.id}`"
         aria-label="Edit metadata item"
         @click="openDialog(item, 'edit')"
       />
       <v-icon
-        v-if="canDelete && item._scope !== 'system'"
+        v-if="canDelete && (item._scope !== 'system' || canManageSystem)"
         :icon="mdiTrashCanOutline"
         :data-testid="`delete-metadata-${item.id}`"
         aria-label="Delete metadata item"
@@ -65,8 +65,9 @@ import { mdiTrashCanOutline, mdiPencil } from '@mdi/js'
 const props = defineProps<{
   search: string | undefined
   workspaceId?: string
-  canEdit: Boolean
-  canDelete: Boolean
+  canEdit: boolean
+  canDelete: boolean
+  canManageSystem?: boolean
   scope?: 'workspace' | 'system' | 'all'
 }>()
 

--- a/apps/data-management/src/components/Metadata/ResultQualifierTable.vue
+++ b/apps/data-management/src/components/Metadata/ResultQualifierTable.vue
@@ -11,14 +11,14 @@
     </template>
     <template v-slot:item.actions="{ item }">
       <v-icon
-        v-if="canEdit && item._scope !== 'system'"
+        v-if="canEdit && (item._scope !== 'system' || canManageSystem)"
         :icon="mdiPencil"
         :data-testid="`edit-metadata-${item.id}`"
         aria-label="Edit metadata item"
         @click="openDialog(item, 'edit')"
       />
       <v-icon
-        v-if="canDelete && item._scope !== 'system'"
+        v-if="canDelete && (item._scope !== 'system' || canManageSystem)"
         :icon="mdiTrashCanOutline"
         :data-testid="`delete-metadata-${item.id}`"
         aria-label="Delete metadata item"
@@ -65,8 +65,9 @@ import { mdiTrashCanOutline, mdiPencil } from '@mdi/js'
 const props = defineProps<{
   search: string | undefined
   workspaceId?: string
-  canEdit: Boolean
-  canDelete: Boolean
+  canEdit: boolean
+  canDelete: boolean
+  canManageSystem?: boolean
   scope?: 'workspace' | 'system' | 'all'
 }>()
 

--- a/apps/data-management/src/components/Metadata/ResultQualifierTable.vue
+++ b/apps/data-management/src/components/Metadata/ResultQualifierTable.vue
@@ -3,7 +3,7 @@
     :headers="headers"
     :items="items"
     :search="search"
-    :style="{ 'max-height': `400px` }"
+    height="100%"
     fixed-header
   >
     <template v-slot:item.scope="{ item }">

--- a/apps/data-management/src/components/Metadata/UnitTable.vue
+++ b/apps/data-management/src/components/Metadata/UnitTable.vue
@@ -3,7 +3,7 @@
     :headers="UnitHeaders"
     :items="sortedItems"
     :search="search"
-    :style="{ 'max-height': `400px` }"
+    height="100%"
     fixed-header
   >
     <template v-slot:item.scope="{ item }">

--- a/apps/data-management/src/components/Metadata/UnitTable.vue
+++ b/apps/data-management/src/components/Metadata/UnitTable.vue
@@ -11,14 +11,14 @@
     </template>
     <template v-slot:item.actions="{ item }">
       <v-icon
-        v-if="canEdit && item._scope !== 'system'"
+        v-if="canEdit && (item._scope !== 'system' || canManageSystem)"
         :icon="mdiPencil"
         :data-testid="`edit-metadata-${item.id}`"
         aria-label="Edit metadata item"
         @click="openDialog(item, 'edit')"
       />
       <v-icon
-        v-if="canDelete && item._scope !== 'system'"
+        v-if="canDelete && (item._scope !== 'system' || canManageSystem)"
         :icon="mdiTrashCanOutline"
         :data-testid="`delete-metadata-${item.id}`"
         aria-label="Delete metadata item"
@@ -65,8 +65,9 @@ import { mdiTrashCanOutline, mdiPencil } from '@mdi/js'
 const props = defineProps<{
   search: string | undefined
   workspaceId?: string
-  canEdit: Boolean
-  canDelete: Boolean
+  canEdit: boolean
+  canDelete: boolean
+  canManageSystem?: boolean
   scope?: 'workspace' | 'system' | 'all'
 }>()
 

--- a/apps/data-management/src/components/VisualizeData/DataVisFiltersDrawer.vue
+++ b/apps/data-management/src/components/VisualizeData/DataVisFiltersDrawer.vue
@@ -1,5 +1,9 @@
 <template>
-  <aside v-if="sidebar.isOpen" class="datavis-filters-panel">
+  <v-navigation-drawer
+    v-model="sidebar.isOpen"
+    width="400"
+    class="datavis-filters-drawer border-r border-slate-200 bg-white text-slate-900"
+  >
     <div class="flex h-full flex-col gap-4 px-4 py-4">
       <div class="flex items-center justify-between px-1">
         <div class="text-[11px] uppercase tracking-[0.25em] text-slate-500">
@@ -8,7 +12,7 @@
         <v-btn
           color="primary"
           variant="outlined"
-          rounded="xl"
+          rounded
           :append-icon="mdiClose"
           class="text-xs"
           @click="clearFilters"
@@ -169,7 +173,7 @@
         </div>
       </div>
     </div>
-  </aside>
+  </v-navigation-drawer>
 </template>
 
 <script setup lang="ts">
@@ -393,35 +397,7 @@ watch(
   text-overflow: ellipsis;
 }
 
-/* Floating "island" card, matching the filter panel on Browse Monitoring
-   Sites (BrowseFilterTool.vue) exactly: same radius, same translucent
-   background, same shadow (--hs-shadow-float, sourced from Vuetify's own
-   card shadow) instead of a flush, square-cornered drawer. Browse's panel
-   is a real <v-card>, so it picks up that shadow from Vuetify directly;
-   this is a plain element, so it's applied explicitly here. */
-.datavis-filters-panel {
-  width: 340px;
-  max-width: 100%;
-  flex-shrink: 0;
-  min-height: 0;
-  border-radius: var(--hs-radius-lg);
-  background: var(--hs-surface-floating);
-  box-shadow: var(--hs-shadow-float);
-  color: var(--hs-text-primary);
-  overflow: hidden;
+.datavis-filters-drawer {
   z-index: 1;
-}
-
-@media (max-width: 700px) {
-  .datavis-filters-panel {
-    position: absolute;
-    inset: 0;
-    width: auto;
-    /* Fully opaque on mobile, where the panel covers the plot/table instead
-       of a map, so underlying content doesn't show through. */
-    background: var(--hs-surface);
-    border-radius: 0;
-    z-index: 30;
-  }
 }
 </style>

--- a/apps/data-management/src/components/VisualizeData/DataVisNavRail.vue
+++ b/apps/data-management/src/components/VisualizeData/DataVisNavRail.vue
@@ -1,101 +1,84 @@
 <template>
-  <nav class="nav-rail" :style="{ width: `${railWidth}px` }">
-    <div class="rail-main">
-      <button
-        type="button"
-        class="rail-btn"
-        :class="{ active: isOpen }"
-        :style="
-          isOpen ? { '--accent': FILTERS_ACCENT, '--accent-light': FILTERS_ACCENT_LIGHT } : {}
-        "
-        :aria-pressed="isOpen"
-        aria-label="Toggle filters drawer"
-        :title="drawerTooltip"
-        @click="sidebar.toggle"
+  <v-navigation-drawer
+    permanent
+    rail
+    :width="railWidth"
+    :rail-width="railWidth"
+    class="datavis-rail"
+  >
+    <div class="flex h-full flex-col items-center gap-3 py-3">
+      <v-tooltip
+        :text="drawerTooltip"
+        location="right"
+        :open-delay="0"
+        :close-delay="0"
       >
-        <span
-          class="rail-pill"
-          :style="isOpen ? { background: FILTERS_ACCENT_LIGHT } : {}"
-        >
-          <v-icon
-            :icon="isOpen ? mdiMenuOpen : mdiMenuClose"
-            size="22"
-            :color="isOpen ? FILTERS_ACCENT : undefined"
-          />
-        </span>
-        <span
-          class="rail-label"
-          :style="isOpen ? { color: FILTERS_ACCENT, fontWeight: 600 } : {}"
-        >
-          Filters
-        </span>
-      </button>
+        <template #activator="{ props }">
+          <v-btn
+            v-bind="props"
+            icon
+            size="large"
+            rounded="lg"
+            :color="isOpen ? 'primary' : 'grey'"
+            :variant="isOpen ? 'tonal' : 'text'"
+            :aria-pressed="isOpen"
+            aria-label="Toggle filters drawer"
+            @click="sidebar.toggle"
+          >
+            <v-icon :icon="isOpen ? mdiMenuOpen : mdiMenuClose" />
+          </v-btn>
+        </template>
+      </v-tooltip>
 
-      <div class="rail-divider" />
+      <div class="my-1 h-px w-8 bg-slate-200" />
 
-      <button
-        type="button"
-        class="rail-btn"
-        :class="{ active: showPlot }"
-        :style="
-          showPlot ? { '--accent': PLOT_ACCENT, '--accent-light': PLOT_ACCENT_LIGHT } : {}
-        "
-        :aria-pressed="showPlot"
-        aria-label="Toggle plot visibility"
-        :title="plotTooltip"
-        @click="togglePlot"
+      <v-tooltip
+        :text="plotTooltip"
+        location="right"
+        :open-delay="0"
+        :close-delay="0"
       >
-        <span
-          class="rail-pill"
-          :style="showPlot ? { background: PLOT_ACCENT_LIGHT } : {}"
-        >
-          <v-icon
-            :icon="mdiChartLine"
-            size="22"
-            :color="showPlot ? PLOT_ACCENT : undefined"
-          />
-        </span>
-        <span
-          class="rail-label"
-          :style="showPlot ? { color: PLOT_ACCENT, fontWeight: 600 } : {}"
-        >
-          Plot
-        </span>
-      </button>
+        <template #activator="{ props }">
+          <v-btn
+            v-bind="props"
+            icon
+            size="large"
+            rounded="lg"
+            :color="showPlot ? 'primary' : 'grey'"
+            :variant="showPlot ? 'tonal' : 'text'"
+            :aria-pressed="showPlot"
+            aria-label="Toggle plot visibility"
+            @click="togglePlot"
+          >
+            <v-icon :icon="mdiChartLine" />
+          </v-btn>
+        </template>
+      </v-tooltip>
 
-      <button
-        type="button"
-        class="rail-btn"
-        :class="{ active: showTable }"
-        :style="
-          showTable
-            ? { '--accent': TABLE_ACCENT, '--accent-light': TABLE_ACCENT_LIGHT }
-            : {}
-        "
-        :aria-pressed="showTable"
-        aria-label="Toggle datastream table visibility"
-        :title="tableTooltip"
-        @click="toggleTable"
+      <v-tooltip
+        :text="tableTooltip"
+        location="right"
+        :open-delay="0"
+        :close-delay="0"
       >
-        <span
-          class="rail-pill"
-          :style="showTable ? { background: TABLE_ACCENT_LIGHT } : {}"
-        >
-          <v-icon
-            :icon="showTable ? mdiTable : mdiTableOff"
-            size="22"
-            :color="showTable ? TABLE_ACCENT : undefined"
-          />
-        </span>
-        <span
-          class="rail-label"
-          :style="showTable ? { color: TABLE_ACCENT, fontWeight: 600 } : {}"
-        >
-          Table
-        </span>
-      </button>
+        <template #activator="{ props }">
+          <v-btn
+            v-bind="props"
+            icon
+            size="large"
+            rounded="lg"
+            :color="showTable ? 'primary' : 'grey'"
+            :variant="showTable ? 'tonal' : 'text'"
+            :aria-pressed="showTable"
+            aria-label="Toggle datastream table visibility"
+            @click="toggleTable"
+          >
+            <v-icon :icon="showTable ? mdiTable : mdiTableOff" />
+          </v-btn>
+        </template>
+      </v-tooltip>
     </div>
-  </nav>
+  </v-navigation-drawer>
 </template>
 
 <script setup lang="ts">
@@ -112,21 +95,11 @@ import {
   mdiTableOff,
 } from '@mdi/js'
 
-// Accent colors reference the same design tokens (styles/tokens.scss) as
-// the Job Orchestration nav rail's accent palette, so the two rails read as
-// the same product surface and can't drift into slightly-different blues.
-const FILTERS_ACCENT = 'var(--hs-accent-blue)'
-const FILTERS_ACCENT_LIGHT = 'var(--hs-accent-blue-bg)'
-const PLOT_ACCENT = 'var(--hs-accent-green)'
-const PLOT_ACCENT_LIGHT = 'var(--hs-accent-green-bg)'
-const TABLE_ACCENT = 'var(--hs-accent-purple)'
-const TABLE_ACCENT_LIGHT = 'var(--hs-accent-purple-bg)'
-
 const sidebar = useSidebarStore()
 const { isOpen } = storeToRefs(sidebar)
 const { showPlot, showTable } = storeToRefs(useDataVisStore())
 const { xs } = useDisplay()
-const railWidth = computed(() => (xs.value ? 76 : 88))
+const railWidth = computed(() => (xs.value ? 56 : 64))
 
 const drawerTooltip = computed(() =>
   isOpen.value ? 'Hide filters panel' : 'Show filters panel'
@@ -156,67 +129,9 @@ const toggleTable = () => {
 </script>
 
 <style scoped>
-/* Mirrors the nav rail on the Job Orchestration page
-   (OrchestrationNavRail.vue) — pill icons with labels underneath, instead of
-   the plain icon-only rail this page previously used. */
-.nav-rail {
-  border-right: 1px solid var(--hs-border);
-  background: var(--hs-surface-muted);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: var(--hs-space-16) 0;
-  flex-shrink: 0;
+.datavis-rail {
   z-index: 20;
-}
-.rail-main {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--hs-space-2);
-  width: 100%;
-}
-.rail-divider {
-  margin: var(--hs-space-6) 0;
-  height: 1px;
-  width: 32px;
-  background: var(--hs-border);
-}
-.rail-btn {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--hs-space-4);
-  padding: var(--hs-space-8) var(--hs-space-4);
-  width: 100%;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  font-family: inherit;
-}
-.rail-btn:hover .rail-pill {
-  background: rgba(0, 0, 0, 0.05);
-}
-.rail-pill {
-  width: 58px;
-  height: 32px;
-  border-radius: var(--hs-radius-xl);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  transition: background 0.15s;
-}
-.rail-label {
-  font-size: var(--hs-font-2xs);
-  color: var(--hs-text-secondary);
-  line-height: 1.2;
-  text-align: center;
-}
-
-@media (max-width: 600px) {
-  .rail-pill {
-    width: 50px;
-  }
+  background: #ffffff;
+  border-right: 1px solid #e2e8f0;
 }
 </style>

--- a/apps/data-management/src/components/Workspace/AccessControl/ManageCollaborators.vue
+++ b/apps/data-management/src/components/Workspace/AccessControl/ManageCollaborators.vue
@@ -17,9 +17,6 @@
     roles. Viewers can see everything in the workspace but cannot edit. Editors
     can create, read, update, and delete all sites, metadata, and datastreams as
     well as set their visibility. Users can remove themselves as collaborators.
-    You can add either a user's email or a service account's email; service
-    accounts can collaborate on workspaces other than the one where they were
-    created.
   </p>
 
   <v-alert
@@ -115,16 +112,6 @@
           <td>
             <div class="font-weight-medium">
               {{ item.name }}
-              <v-chip
-                v-if="item.isServiceAccount"
-                size="x-small"
-                class="ml-2"
-                variant="tonal"
-                color="blue-darken-2"
-                data-testid="collaborator-service-account-chip"
-              >
-                Service account
-              </v-chip>
             </div>
             <div class="text-caption text-medium-emphasis">
               {{ item.email }}
@@ -308,7 +295,9 @@ async function onAddCollaborator() {
       selectedRole.value.id
     )
     if (res.ok) {
-      collaboratorList.value.push(collaboratorToFormData(res.data))
+      if (res.data.user && !res.data.serviceAccount) {
+        collaboratorList.value.push(collaboratorToFormData(res.data))
+      }
       collaboratorList.value.sort((a, b) => a.name.localeCompare(b.name))
       Snackbar.success('Collaborator added to workspace.')
       showAddCollaborator.value = false
@@ -356,7 +345,9 @@ async function onRemoveCollaborator(email: string) {
 }
 
 const setCollaboratorList = (collaborators: Collaborator[]) => {
-  collaboratorList.value = collaborators.map((c) => collaboratorToFormData(c))
+  collaboratorList.value = collaborators
+    .filter((collaborator) => collaborator.user && !collaborator.serviceAccount)
+    .map((collaborator) => collaboratorToFormData(collaborator))
 
   if (props.workspace?.owner) {
     collaboratorList.value.unshift({
@@ -365,7 +356,6 @@ const setCollaboratorList = (collaborators: Collaborator[]) => {
       name: props.workspace.owner.name,
       role: { name: 'Owner' },
       organization: props.workspace.owner.organizationName || 'No Organization',
-      isServiceAccount: false,
       isOwner: true,
       isBeingEdited: false,
       isSaving: false,
@@ -380,7 +370,7 @@ async function onCancelEdit(item: any) {
 }
 
 const collaboratorToFormData = (c: Collaborator) => {
-  const contact = c.serviceAccount ?? c.user
+  const contact = c.user
   return {
     email: contact?.email ?? '',
     value: contact?.email ?? '',
@@ -388,7 +378,6 @@ const collaboratorToFormData = (c: Collaborator) => {
     role: c.role,
     pendingRole: c.role,
     organization: c.user?.organizationName || 'No Organization',
-    isServiceAccount: !!c.serviceAccount,
     isOwner: false,
     isBeingEdited: false,
     isSaving: false,

--- a/apps/data-management/src/components/Workspace/AccessControl/ManageServiceAccounts.vue
+++ b/apps/data-management/src/components/Workspace/AccessControl/ManageServiceAccounts.vue
@@ -1,131 +1,134 @@
 <template>
-  <div class="service-accounts-header">
-    <h6 class="text-h6">Service accounts</h6>
-    <v-icon
-      :icon="mdiHelpCircleOutline"
-      @click="showServiceAccountHelp = !showServiceAccountHelp"
-      color="grey"
-      size="18"
-      class="service-accounts-help-icon"
-      aria-label="Toggle service account help"
-      :aria-expanded="showServiceAccountHelp"
-    />
-  </div>
-
-  <p v-if="showServiceAccountHelp" class="service-accounts-help-text">
-    Service accounts provide remote systems with a controlled set of
-    permissions. A service account can collaborate on other workspaces after it
-    is created.
-  </p>
-
-  <v-alert
-    v-if="loadError"
-    type="error"
-    variant="tonal"
-    density="compact"
-    class="mb-3"
-  >
-    <div class="d-flex align-center ga-2">
-      <span>{{ loadError }}</span>
-      <v-spacer />
-      <v-btn variant="text" size="small" @click="reloadData">Retry</v-btn>
-    </div>
-  </v-alert>
-  <v-progress-linear v-if="isLoading" indeterminate class="mb-2" />
-
-  <v-card-text v-if="showNewKey && newKey">
-    <v-alert
-      type="success"
-      border="start"
-      elevation="2"
-      variant="tonal"
-      class="mb-4"
-    >
-      Your service account API key has been generated. Please copy it and store
-      it somewhere safe — you won’t be able to see it again after leaving this
-      page.
-    </v-alert>
-
-    <v-sheet
-      color="grey-lighten-5"
-      class="pa-4 rounded d-flex align-center justify-space-between"
-      border
-    >
-      <span class="text-mono text-wrap break-all">{{ newKey.key }}</span>
-      <v-btn
-        :icon="mdiContentCopy"
-        variant="text"
-        @click="copyKey(newKey.key)"
-        aria-label="Copy service account API key"
+  <div class="service-accounts-section" data-testid="service-accounts-section">
+    <div class="service-accounts-header">
+      <h6 class="text-h6">Service accounts</h6>
+      <v-icon
+        :icon="mdiHelpCircleOutline"
+        @click="showServiceAccountHelp = !showServiceAccountHelp"
+        color="grey"
+        size="18"
+        class="service-accounts-help-icon"
+        aria-label="Toggle service account help"
+        :aria-expanded="showServiceAccountHelp"
       />
-    </v-sheet>
-  </v-card-text>
+    </div>
 
-  <v-card class="hs-table-card service-accounts-table-card" flat>
-    <v-toolbar flat density="compact">
-      <v-spacer />
-      <PermissionTooltip
-        :has-permission="canCreate"
-        message="You don't have permission to create service accounts for this workspace."
-      >
-        <template #default>
-          <v-btn-add class="mr-2" @click="openCreate = true">
-            Create service account
-          </v-btn-add>
-        </template>
-        <template #denied>
-          <v-btn-add class="mr-2" disabled>Create service account</v-btn-add>
-        </template>
-      </PermissionTooltip>
-    </v-toolbar>
+    <p v-if="showServiceAccountHelp" class="service-accounts-help-text">
+      Service accounts provide remote systems with a controlled set of
+      permissions. A service account can collaborate on other workspaces after
+      it is created.
+    </p>
 
-    <v-data-table-virtual
-      :headers="headers"
-      :items="items"
-      :sort-by="sortBy"
-      :search="search"
-      :style="{ 'max-height': `100vh` }"
-      no-data-text="No service accounts available"
-      fixed-header
+    <v-alert
+      v-if="loadError"
+      type="error"
+      variant="tonal"
+      density="compact"
+      class="mb-3"
     >
-      <template #item.id="{ item }">
-        <div class="d-flex align-center">
-          {{ item.id }}
-          <v-icon size="x-small" class="ml-2" @click="copyKey(item.id)">
-            <v-icon :icon="mdiContentCopy" />
-          </v-icon>
-        </div>
-      </template>
+      <div class="d-flex align-center ga-2">
+        <span>{{ loadError }}</span>
+        <v-spacer />
+        <v-btn variant="text" size="small" @click="reloadData">Retry</v-btn>
+      </div>
+    </v-alert>
+    <v-progress-linear v-if="isLoading" indeterminate class="mb-2" />
 
-      <template v-slot:item.actions="{ item }">
+    <v-card-text v-if="showNewKey && newKey">
+      <v-alert
+        type="success"
+        border="start"
+        elevation="2"
+        variant="tonal"
+        class="mb-4"
+      >
+        Your service account API key has been generated. Please copy it and
+        store it somewhere safe — you won’t be able to see it again after
+        leaving this page.
+      </v-alert>
+
+      <v-sheet
+        color="grey-lighten-5"
+        class="pa-4 rounded d-flex align-center justify-space-between"
+        border
+      >
+        <span class="text-mono text-wrap break-all">{{ newKey.key }}</span>
         <v-btn
-          :icon="mdiRefresh"
+          :icon="mdiContentCopy"
           variant="text"
-          size="small"
-          :disabled="!canEdit"
-          :aria-label="`Regenerate ${item.name}`"
-          @click="onOpenRegenerateDialog(item)"
+          @click="copyKey(newKey.key)"
+          aria-label="Copy service account API key"
         />
-        <v-btn
-          :icon="mdiPencil"
-          variant="text"
-          size="small"
-          :disabled="!canEdit"
-          :aria-label="`Edit ${item.name}`"
-          @click="openDialog(item, 'edit')"
-        />
-        <v-btn
-          :icon="mdiTrashCanOutline"
-          variant="text"
-          size="small"
-          color="red-darken-2"
-          :disabled="!canDelete"
-          :aria-label="`Delete ${item.name}`"
-          @click="openDialog(item, 'delete')"
-        />
-      </template>
-    </v-data-table-virtual>
-  </v-card>
+      </v-sheet>
+    </v-card-text>
+
+    <v-card class="hs-table-card service-accounts-table-card" flat>
+      <v-toolbar flat density="compact">
+        <v-spacer />
+        <PermissionTooltip
+          :has-permission="canCreate"
+          message="You don't have permission to create service accounts for this workspace."
+        >
+          <template #default>
+            <v-btn-add class="mr-2" @click="openCreate = true">
+              Create service account
+            </v-btn-add>
+          </template>
+          <template #denied>
+            <v-btn-add class="mr-2" disabled>Create service account</v-btn-add>
+          </template>
+        </PermissionTooltip>
+      </v-toolbar>
+
+      <v-data-table-virtual
+        class="service-accounts-data-table"
+        :headers="headers"
+        :items="items"
+        :sort-by="sortBy"
+        :search="search"
+        height="100%"
+        no-data-text="No service accounts available"
+        fixed-header
+      >
+        <template #item.id="{ item }">
+          <div class="d-flex align-center">
+            {{ item.id }}
+            <v-icon size="x-small" class="ml-2" @click="copyKey(item.id)">
+              <v-icon :icon="mdiContentCopy" />
+            </v-icon>
+          </div>
+        </template>
+
+        <template v-slot:item.actions="{ item }">
+          <v-btn
+            :icon="mdiRefresh"
+            variant="text"
+            size="small"
+            :disabled="!canEdit"
+            :aria-label="`Regenerate ${item.name}`"
+            @click="onOpenRegenerateDialog(item)"
+          />
+          <v-btn
+            :icon="mdiPencil"
+            variant="text"
+            size="small"
+            :disabled="!canEdit"
+            :aria-label="`Edit ${item.name}`"
+            @click="openDialog(item, 'edit')"
+          />
+          <v-btn
+            :icon="mdiTrashCanOutline"
+            variant="text"
+            size="small"
+            color="red-darken-2"
+            :disabled="!canDelete"
+            :aria-label="`Delete ${item.name}`"
+            @click="openDialog(item, 'delete')"
+          />
+        </template>
+      </v-data-table-virtual>
+    </v-card>
+  </div>
 
   <v-dialog v-model="openCreate" width="40rem">
     <ServiceAccountForm
@@ -441,6 +444,13 @@ onMounted(loadRoles)
 </script>
 
 <style scoped>
+.service-accounts-section {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
 .service-accounts-header {
   display: flex;
   align-items: center;
@@ -458,6 +468,16 @@ onMounted(loadRoles)
   margin-bottom: 10px;
 }
 .service-accounts-table-card {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
   margin-top: 6px;
+  overflow: hidden;
+}
+.service-accounts-data-table {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 </style>

--- a/apps/data-management/src/composables/useAllScopeTableLogic.ts
+++ b/apps/data-management/src/composables/useAllScopeTableLogic.ts
@@ -8,8 +8,8 @@ interface WithId {
 /**
  * Like useTableLogic, but for the merged "All" metadata view: fetches a
  * workspace's own items alongside the shared system items and tags each with
- * where it came from, so the table can show a Scope column and only allow
- * editing the rows this workspace actually owns.
+ * where it came from, so the table can show a Scope column and apply
+ * row-level permissions for workspace and system metadata.
  */
 export function useAllScopeTableLogic<T extends WithId>(
   fetchWorkspaceFn: (wsId: string) => Promise<T[]>,
@@ -59,8 +59,12 @@ export function useAllScopeTableLogic<T extends WithId>(
         fetchSystemFn(),
       ])
       items.value = [
-        ...workspaceItems.map((i) => Object.assign(i, { _scope: 'workspace' as const })),
-        ...systemItems.map((i) => Object.assign(i, { _scope: 'system' as const })),
+        ...workspaceItems.map((i) =>
+          Object.assign(i, { _scope: 'workspace' as const })
+        ),
+        ...systemItems.map((i) =>
+          Object.assign(i, { _scope: 'system' as const })
+        ),
       ]
     } catch (error) {
       console.error(`Error fetching table items`, error)

--- a/apps/data-management/src/pages/VisualizeData.vue
+++ b/apps/data-management/src/pages/VisualizeData.vue
@@ -415,12 +415,17 @@ onUnmounted(() => {
   flex-direction: column;
   flex: 1;
   min-width: 0;
-  min-height: 0;
   gap: 12px;
+  --visualize-margin: 16px;
+  margin: var(--visualize-margin);
+  height: calc(
+    100dvh - var(--v-layout-top, 0px) - var(--v-layout-bottom, 0px) -
+      (var(--visualize-margin) * 2)
+  );
 }
 
 .visualize-page {
-  --datavis-rail-width: 88px;
+  --datavis-rail-width: 64px;
   display: flex;
   height: calc(
     100dvh - var(--v-layout-top, 0px) - var(--v-layout-bottom, 0px)
@@ -432,12 +437,6 @@ onUnmounted(() => {
 .visualize-content {
   flex: 1;
   min-width: 0;
-  min-height: 0;
-  display: flex;
-  align-items: stretch;
-  gap: 16px;
-  padding: 16px;
-  box-sizing: border-box;
   position: relative;
 }
 
@@ -455,15 +454,12 @@ onUnmounted(() => {
 }
 
 @media (max-width: 600px) {
-  .visualize-content {
-    gap: 8px;
-    padding: 8px;
-  }
   .visualize-layout {
+    --visualize-margin: 8px;
     gap: 8px;
   }
   .visualize-page {
-    --datavis-rail-width: 76px;
+    --datavis-rail-width: 56px;
   }
 }
 </style>

--- a/apps/data-management/src/pages/Workspaces.vue
+++ b/apps/data-management/src/pages/Workspaces.vue
@@ -291,8 +291,21 @@
             </v-tabs>
           </div>
 
-          <div class="detail-body">
-            <v-window v-model="section">
+          <div
+            class="detail-body"
+            :class="{
+              'detail-body--table':
+                section === 'service-accounts' || section === 'metadata',
+            }"
+          >
+            <v-window
+              v-model="section"
+              class="detail-window"
+              :class="{
+                'detail-window--table':
+                  section === 'service-accounts' || section === 'metadata',
+              }"
+            >
               <v-window-item value="overview">
                 <h6 class="text-h6 mb-1">Overview</h6>
 
@@ -1413,6 +1426,22 @@ onMounted(async () => {
   overflow-y: auto;
   padding: var(--hs-space-16) var(--hs-space-24);
 }
+.detail-body--table {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+.detail-window--table {
+  flex: 1;
+  height: 100%;
+  min-height: 0;
+}
+.detail-window--table :deep(.v-window__container),
+.detail-window--table :deep(.v-window-item) {
+  height: 100%;
+  min-height: 0;
+}
 .workspace-id-cell {
   overflow-wrap: anywhere;
 }
@@ -1532,6 +1561,14 @@ onMounted(async () => {
   .detail-body {
     overflow: visible;
     padding: var(--hs-space-16);
+  }
+  .detail-body--table {
+    display: block;
+  }
+  .detail-window--table,
+  .detail-window--table :deep(.v-window__container),
+  .detail-window--table :deep(.v-window-item) {
+    height: auto;
   }
   .overview-stats {
     flex-wrap: wrap;

--- a/apps/data-management/src/pages/Workspaces.vue
+++ b/apps/data-management/src/pages/Workspaces.vue
@@ -559,6 +559,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useRoute, useRouter } from 'vue-router'
 import hs, {
+  Collaborator,
   PermissionAction,
   PermissionResource,
   Workspace,
@@ -660,14 +661,17 @@ const overviewStatsHasError = ref(false)
 let overviewRequestId = 0
 
 function responseCount(result: PromiseSettledResult<unknown>): number | null {
+  const data = responseData(result)
+  return data === null ? null : data.length
+}
+
+function responseData<T>(result: PromiseSettledResult<unknown>): T[] | null {
   if (result.status === 'rejected') return null
   const response = result.value as {
     ok?: boolean
-    data?: unknown[]
+    data?: T[]
   } | null
-  return response?.ok && Array.isArray(response.data)
-    ? response.data.length
-    : null
+  return response?.ok && Array.isArray(response.data) ? response.data : null
 }
 
 const loadOverviewStats = async (workspaceId: string) => {
@@ -717,6 +721,12 @@ const loadOverviewStats = async (workspaceId: string) => {
     return
 
   const counts = results.map(responseCount)
+  const collaborators = responseData<Collaborator>(results[0])
+  const memberCount = collaborators
+    ? collaborators.filter(
+        (collaborator) => collaborator.user && !collaborator.serviceAccount
+      ).length + 1
+    : null
   const metadataCounts = counts.slice(3)
   const metadata = metadataCounts.every((count) => count !== null)
     ? metadataCounts.reduce<number>((total, count) => total + (count ?? 0), 0)
@@ -724,7 +734,7 @@ const loadOverviewStats = async (workspaceId: string) => {
 
   overviewStats.value = {
     // +1 for the owner, who isn't included in the collaborators list.
-    members: counts[0] === null ? null : counts[0] + 1,
+    members: memberCount,
     sites: counts[1],
     serviceAccounts: canViewServiceAccounts ? counts[2] : null,
     metadata,

--- a/django/tests/e2e/scenarios.py
+++ b/django/tests/e2e/scenarios.py
@@ -224,6 +224,14 @@ def cleanup_scenario(scenario_key):
 def create_scenario(scenario_key):
     marker = _validated_key(scenario_key)
 
+    admin = _user(
+        "admin",
+        marker,
+        first_name="Admin",
+        last_name="User",
+        is_staff=True,
+        is_superuser=True,
+    )
     owner = _user("owner", marker, first_name="Owner", last_name="Johnson")
     editor = _user("editor", marker, first_name="Editor", last_name="Smith")
     viewer = _user("viewer", marker, first_name="Viewer", last_name="Davis")
@@ -260,6 +268,9 @@ def create_scenario(scenario_key):
         organization=organization,
     )
 
+    admin_workspace = WorkspaceFactory(
+        owner=admin, name=_name("Admin", marker), is_private=True
+    )
     public_workspace = WorkspaceFactory(
         owner=owner, name=_name("Public", marker), is_private=False
     )
@@ -354,6 +365,11 @@ def create_scenario(scenario_key):
         code=f"SystemResultQualifier-{marker}",
         description=f"E2E scenario result qualifier {marker}",
     )
+    editable_system_qualifier = ResultQualifierFactory(
+        workspace=None,
+        code=f"EditableSystemResultQualifier-{marker}",
+        description=f"Editable E2E system result qualifier {marker}",
+    )
 
     public_datastream = _datastream(
         public_monitoring_site,
@@ -438,6 +454,7 @@ def create_scenario(scenario_key):
     return {
         "scenarioKey": marker,
         "users": {
+            "admin": user_data(admin),
             "owner": user_data(owner),
             "editor": user_data(editor),
             "viewer": user_data(viewer),
@@ -448,6 +465,7 @@ def create_scenario(scenario_key):
         },
         "fixtures": {
             "workspaces": {
+                "admin": {"id": str(admin_workspace.id), "name": admin_workspace.name},
                 "public": {"id": str(public_workspace.id), "name": public_workspace.name},
                 "private": {"id": str(private_workspace.id), "name": private_workspace.name},
                 "transfer": {"id": str(transfer_workspace.id), "name": transfer_workspace.name},
@@ -518,6 +536,10 @@ def create_scenario(scenario_key):
                 "systemMethod": {
                     "id": str(system_metadata["method"].id),
                     "name": system_metadata["method"].name,
+                },
+                "editableSystemResultQualifier": {
+                    "id": str(editable_system_qualifier.id),
+                    "name": editable_system_qualifier.code,
                 },
             },
             "orchestration": {

--- a/django/tests/e2e/scenarios.py
+++ b/django/tests/e2e/scenarios.py
@@ -215,8 +215,10 @@ def cleanup_scenario(scenario_key):
     Unit.objects.filter(
         symbol=f"S{marker[-4:]}", workspace__isnull=True
     ).delete()
+    # The admin CRUD test may rename the editable qualifier before failing,
+    # so match the scenario marker rather than only its original code.
     ResultQualifier.objects.filter(
-        code=f"SystemResultQualifier-{marker}", workspace__isnull=True
+        code__contains=marker, workspace__isnull=True
     ).delete()
     Organization.objects.filter(code=f"E2E-{marker}").delete()
 

--- a/django/tests/e2e/test_scenarios.py
+++ b/django/tests/e2e/test_scenarios.py
@@ -24,8 +24,8 @@ def test_scenario_uses_generated_ids_and_cleans_up_all_workspace_data():
     )
     assert scenario["fixtures"]["workspaces"]["public"]["id"]
     assert scenario["fixtures"]["monitoringSites"]["public"]["id"]
-    assert User.objects.filter(email__contains="+scenario-one@").count() == 7
-    assert Workspace.objects.count() == 3
+    assert User.objects.filter(email__contains="+scenario-one@").count() == 8
+    assert Workspace.objects.count() == 4
     assert MonitoringSite.objects.count() == 5
 
     cleanup_scenario("scenario-one")
@@ -51,6 +51,6 @@ def test_scenarios_do_not_share_users_or_resource_ids():
 
     cleanup_scenario("scenario-first")
     assert Role.objects.count() == 3
-    assert User.objects.filter(email__contains="+scenario-second@").count() == 7
+    assert User.objects.filter(email__contains="+scenario-second@").count() == 8
 
     cleanup_scenario("scenario-second")

--- a/django/tests/e2e/test_scenarios.py
+++ b/django/tests/e2e/test_scenarios.py
@@ -1,7 +1,7 @@
 import pytest
 
 from core.iam.models import Role, User, Workspace
-from core.sta.models import MonitoringSite
+from core.sta.models import MonitoringSite, ResultQualifier
 from tests.core.iam.factories import RoleFactory
 from tests.e2e.scenarios import cleanup_scenario, create_scenario
 
@@ -27,12 +27,20 @@ def test_scenario_uses_generated_ids_and_cleans_up_all_workspace_data():
     assert User.objects.filter(email__contains="+scenario-one@").count() == 8
     assert Workspace.objects.count() == 4
     assert MonitoringSite.objects.count() == 5
+    editable_qualifier = ResultQualifier.objects.get(
+        code="EditableSystemResultQualifier-scenario-one", workspace__isnull=True
+    )
+    editable_qualifier.code += "-UPDATED"
+    editable_qualifier.save(update_fields=["code"])
 
     cleanup_scenario("scenario-one")
 
     assert not User.objects.filter(email__contains="+scenario-one@").exists()
     assert not Workspace.objects.exists()
     assert not MonitoringSite.objects.exists()
+    assert not ResultQualifier.objects.filter(
+        code__contains="scenario-one", workspace__isnull=True
+    ).exists()
 
 
 def test_scenarios_do_not_share_users_or_resource_ids():


### PR DESCRIPTION
Resolves #508 

For the datastream table on the SiteDetails page, I remove the scroll ability of the table and replaced it with progressive rendering which will load datastreams about 15-20 ahead of what the user can see as they scroll. Probably in the future, server side pagination and filtering will be even better, but this should work just fine for now. 

For the workspace management tables, I set the height of the table to the remaining view height since they already have most of the height of the page to work with. They continue to use Vuetify's virtual pagination like before, but this removed the need for a second scroll bar on the main page.